### PR TITLE
Adding metaball and openvdb meshers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ option(WITH_OPENIMAGEDENOISE   "Enable the OpenImageDenoise compositing node" ON
 
 option(WITH_OPENSUBDIV    "Enable OpenSubdiv for surface subdivision" ${_init_OPENSUBDIV})
 
-option(WITH_OPENVDB       "Enable features relying on OpenVDB" OFF)
+option(WITH_OPENVDB       "Enable features relying on OpenVDB" ON)
 option(WITH_OPENVDB_BLOSC "Enable blosc compression for OpenVDB, only enable if OpenVDB was built with blosc support" OFF)
 option(WITH_OPENVDB_3_ABI_COMPATIBLE "Assume OpenVDB library has been compiled with version 3 ABI compatibility" OFF)
 mark_as_advanced(WITH_OPENVDB_3_ABI_COMPATIBLE)

--- a/intern/cycles/blender/blender_mesh.cpp
+++ b/intern/cycles/blender/blender_mesh.cpp
@@ -912,6 +912,61 @@ static void sync_mesh_fluid_motion(BL::Object &b_ob, Scene *scene, Mesh *mesh)
   }
 }
 
+static bool sync_mesh_precalculated_motion(BL::Mesh& b_mesh, BL::Object& b_ob, BL::Scene& b_scene, Scene *scene, Mesh *mesh)
+{
+	if(scene->need_motion() == Scene::MOTION_NONE)
+		return false;
+
+	BL::RemeshModifier b_remesher = object_metaball_remesher_find(b_ob);
+	if (!(b_remesher))
+		return false;
+
+	/* Find or add attribute */
+	float3 *P = &mesh->verts[0];
+	Attribute *attr_mP = mesh->attributes.find(ATTR_STD_MOTION_VERTEX_POSITION);
+
+	if(!attr_mP) {
+		attr_mP = mesh->attributes.add(ATTR_STD_MOTION_VERTEX_POSITION);
+	}
+
+	/* Only export previous and next frame, we don't have any in between data. */
+	float motion_times[2] = {-1.0f, 1.0f};
+	for(int step = 0; step < 2; step++) {
+		/* those are TIMES, but treated like Frames ? makes too high values, so take fps into account*/
+		float relative_time = motion_times[step] * scene->motion_shutter_time() * 0.5f / b_scene.render().fps();
+		float3 *mP = attr_mP->data_float3() + step*mesh->verts.size();
+
+		int i = 0;
+
+		{
+			BL::MeshVertexFloatPropertyLayer vlX = b_mesh.vertex_layers_float[std::string("velX")];
+			BL::MeshVertexFloatPropertyLayer vlY = b_mesh.vertex_layers_float[std::string("velY")];
+			BL::MeshVertexFloatPropertyLayer vlZ = b_mesh.vertex_layers_float[std::string("velZ")];
+
+			BL::Pointer ptrX = (BL::Pointer)vlX;
+			BL::Pointer ptrY = (BL::Pointer)vlY;
+			BL::Pointer ptrZ = (BL::Pointer)vlZ;
+
+			if (!ptrX || !ptrY || !ptrZ || vlX.data.length() != mesh->verts.size())
+			{
+				return false;
+			}
+
+			for(i = 0; i < mesh->verts.size(); i++)
+			{
+				float x = vlX.data[i].value();
+				float y = vlY.data[i].value();
+				float z = vlZ.data[i].value();
+
+				//printf("Vel %f %f %f\n", (double)x, (double)y, (double)z);
+				mP[i] = P[i] + make_float3(x, y, z) * relative_time;
+			}
+		}
+	}
+
+	return true;
+}
+
 Mesh *BlenderSync::sync_mesh(BL::Depsgraph &b_depsgraph,
                              BL::Object &b_ob,
                              BL::Object &b_ob_instance,
@@ -1039,6 +1094,9 @@ Mesh *BlenderSync::sync_mesh(BL::Depsgraph &b_depsgraph,
         sync_curves(mesh, b_mesh, b_ob, false);
       }
 
+      /* Sync precalculated motion vectors, aka Metaball remesher */
+	  sync_mesh_precalculated_motion(b_mesh, b_ob, b_scene, scene, mesh);
+
       free_object_to_mesh(b_data, b_ob, b_mesh);
     }
   }
@@ -1096,6 +1154,11 @@ void BlenderSync::sync_mesh_motion(BL::Depsgraph &b_depsgraph,
   BL::DomainFluidSettings b_fluid_domain = object_fluid_domain_find(b_ob);
   if (b_fluid_domain)
     return;
+
+  /* other precalculated motion (metaball remesher for now only) */
+  BL::RemeshModifier b_remesher = object_metaball_remesher_find(b_ob);
+  if (b_remesher)
+	return;
 
   if (ccl::BKE_object_is_deform_modified(b_ob, b_scene, preview)) {
     /* get derived mesh */

--- a/intern/cycles/blender/blender_util.h
+++ b/intern/cycles/blender/blender_util.h
@@ -554,6 +554,22 @@ static inline BL::DomainFluidSettings object_fluid_domain_find(BL::Object b_ob)
   return BL::DomainFluidSettings(PointerRNA_NULL);
 }
 
+static inline BL::RemeshModifier object_metaball_remesher_find(BL::Object b_ob)
+{
+	BL::Object::modifiers_iterator b_mod;
+
+	for(b_ob.modifiers.begin(b_mod); b_mod != b_ob.modifiers.end(); ++b_mod) {
+		if(b_mod->is_a(&RNA_RemeshModifier)) {
+			BL::RemeshModifier b_fmd(*b_mod);
+
+			if(b_fmd.mode() == BL::RemeshModifier::mode_METABALL)
+				return b_fmd;
+		}
+	}
+
+	return BL::RemeshModifier(PointerRNA_NULL);
+}
+	
 static inline Mesh::SubdivisionType object_subdivision_type(BL::Object &b_ob,
                                                             bool preview,
                                                             bool experimental)

--- a/intern/openvdb/CMakeLists.txt
+++ b/intern/openvdb/CMakeLists.txt
@@ -21,6 +21,7 @@
 set(INC
   .
   intern
+  ../guardedalloc
 )
 
 set(INC_SYS
@@ -61,6 +62,8 @@ if(WITH_OPENVDB)
     intern/openvdb_primitive.cpp
     #intern/openvdb_render.cpp
     intern/particle_tools.cpp
+    intern/openvdb_level_set.cc
+    intern/openvdb_transform.cc
     openvdb_capi.cc
     openvdb_util.cc
 
@@ -70,6 +73,8 @@ if(WITH_OPENVDB)
     intern/particle_tools.h
     openvdb_util.h 
     openvdb_intern.h
+    intern/openvdb_level_set.h
+    intern/openvdb_transform.h
   )
 
   if(WITH_OPENVDB_BLOSC)

--- a/intern/openvdb/intern/openvdb_level_set.cc
+++ b/intern/openvdb/intern/openvdb_level_set.cc
@@ -1,0 +1,179 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) 2015 Blender Foundation.
+ * All rights reserved.
+ */
+
+#include "openvdb_level_set.h"
+#include "openvdb_util.h"
+#include "openvdb_capi.h"
+#include "MEM_guardedalloc.h"
+#include "openvdb/tools/Composite.h"
+
+OpenVDBLevelSet::OpenVDBLevelSet()
+{
+  openvdb::initialize();
+}
+
+OpenVDBLevelSet::~OpenVDBLevelSet()
+{
+}
+
+void OpenVDBLevelSet::OpenVDB_mesh_to_level_set(const float *vertices,
+                                                const unsigned int *faces,
+                                                const unsigned int totvertices,
+                                                const unsigned int totfaces,
+                                                openvdb::math::Transform::Ptr xform)
+{
+  std::vector<openvdb::Vec3s> points;
+  std::vector<openvdb::Vec3I> triangles;
+  std::vector<openvdb::Vec4I> quads;
+
+  for (unsigned int i = 0; i < totvertices; i++) {
+    openvdb::Vec3s v(vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
+    points.push_back(v);
+  }
+
+  for (unsigned int i = 0; i < totfaces; i++) {
+    openvdb::Vec3I f(faces[i * 3], faces[i * 3 + 1], faces[i * 3 + 2]);
+    triangles.push_back(f);
+  }
+
+  this->grid = openvdb::tools::meshToLevelSet<openvdb::FloatGrid>(
+      *xform, points, triangles, quads, 1);
+}
+
+void OpenVDBLevelSet::OpenVDB_volume_to_mesh(OpenVDBVolumeToMeshData *mesh,
+                                             const double isovalue,
+                                             const double adaptivity,
+                                             const bool relax_disoriented_triangles)
+{
+  std::vector<openvdb::Vec3s> out_points;
+  std::vector<openvdb::Vec4I> out_quads;
+  std::vector<openvdb::Vec3I> out_tris;
+  openvdb::tools::volumeToMesh<openvdb::FloatGrid>(*this->grid,
+                                                   out_points,
+                                                   out_tris,
+                                                   out_quads,
+                                                   isovalue,
+                                                   adaptivity,
+                                                   relax_disoriented_triangles);
+  mesh->vertices = (float *)MEM_malloc_arrayN(
+      out_points.size(), 3 * sizeof(float), "openvdb remesher out verts");
+  mesh->quads = (unsigned int *)MEM_malloc_arrayN(
+      out_quads.size(), 4 * sizeof(unsigned int), "openvdb remesh out quads");
+  mesh->triangles = NULL;
+  if (out_tris.size() > 0) {
+    mesh->triangles = (unsigned int *)MEM_malloc_arrayN(
+        out_tris.size(), 3 * sizeof(unsigned int), "openvdb remesh out tris");
+  }
+
+  mesh->totvertices = out_points.size();
+  mesh->tottriangles = out_tris.size();
+  mesh->totquads = out_quads.size();
+
+  for (unsigned int i = 0; i < out_points.size(); i++) {
+    mesh->vertices[i * 3] = out_points[i].x();
+    mesh->vertices[i * 3 + 1] = out_points[i].y();
+    mesh->vertices[i * 3 + 2] = out_points[i].z();
+  }
+
+  for (unsigned int i = 0; i < out_quads.size(); i++) {
+    mesh->quads[i * 4] = out_quads[i].x();
+    mesh->quads[i * 4 + 1] = out_quads[i].y();
+    mesh->quads[i * 4 + 2] = out_quads[i].z();
+    mesh->quads[i * 4 + 3] = out_quads[i].w();
+  }
+
+  for (unsigned int i = 0; i < out_tris.size(); i++) {
+    mesh->triangles[i * 3] = out_tris[i].x();
+    mesh->triangles[i * 3 + 1] = out_tris[i].y();
+    mesh->triangles[i * 3 + 2] = out_tris[i].z();
+  }
+}
+
+void OpenVDBLevelSet::OpenVDB_level_set_filter(OpenVDBLevelSet_FilterType filter_type,
+                                               int width,
+                                               int iterations,
+                                               int filter_bias)
+{
+
+  if (!this->grid) {
+    return;
+  }
+
+  if (this->grid && this->grid->getGridClass() != openvdb::GRID_LEVEL_SET) {
+    return;
+  }
+
+  openvdb::tools::LevelSetFilter<openvdb::FloatGrid> filter(*this->grid);
+  filter.setSpatialScheme((openvdb::math::BiasedGradientScheme)filter_bias);
+  switch (filter_type) {
+    case OPENVDB_LEVELSET_FILTER_GAUSSIAN:
+      filter.gaussian(width);
+      break;
+    case OPENVDB_LEVELSET_FILTER_MEDIAN:
+      filter.median(width);
+      break;
+    case OPENVDB_LEVELSET_FILTER_MEAN:
+      filter.mean(width);
+      break;
+    case OPENVDB_LEVELSET_FILTER_MEAN_CURVATURE:
+      filter.meanCurvature();
+      break;
+    case OPENVDB_LEVELSET_FILTER_LAPLACIAN:
+      filter.laplacian();
+      break;
+    case OPENVDB_LEVELSET_FILTER_DILATE:
+      filter.offset(-iterations / 100.0);
+      break;
+    case OPENVDB_LEVELSET_FILTER_ERODE:
+      filter.offset(iterations / 100.0);
+      break;
+  }
+}
+openvdb::FloatGrid::Ptr OpenVDBLevelSet::OpenVDB_CSG_operation(
+    openvdb::FloatGrid::Ptr gridA,
+    openvdb::FloatGrid::Ptr gridB,
+    OpenVDBLevelSet_CSGOperation operation)
+{
+  openvdb::FloatGrid::Ptr gridA_copy = gridA;  //->deepCopy();
+  openvdb::FloatGrid::Ptr gridB_copy = gridB;  //->deepCopy();
+
+  switch (operation) {
+    case OPENVDB_LEVELSET_CSG_UNION:
+      openvdb::tools::csgUnion(*gridA_copy, *gridB_copy);
+      break;
+    case OPENVDB_LEVELSET_CSG_DIFFERENCE:
+      openvdb::tools::csgDifference(*gridA_copy, *gridB_copy);
+      break;
+    case OPENVDB_LEVELSET_CSG_INTERSECTION:
+      openvdb::tools::csgIntersection(*gridA_copy, *gridB_copy);
+      break;
+  }
+
+  return gridA_copy;
+}
+
+openvdb::FloatGrid::Ptr OpenVDBLevelSet::OpenVDB_level_set_get_grid()
+{
+  return this->grid;
+}
+
+void OpenVDBLevelSet::OpenVDB_level_set_set_grid(openvdb::FloatGrid::Ptr grid)
+{
+  this->grid = grid;
+}

--- a/intern/openvdb/intern/openvdb_level_set.h
+++ b/intern/openvdb/intern/openvdb_level_set.h
@@ -1,0 +1,74 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) 2015 Blender Foundation.
+ * All rights reserved.
+ */
+
+#ifndef __OPENVDB_LEVEL_SET_H__
+#define __OPENVDB_LEVEL_SET_H__
+
+#include <openvdb/openvdb.h>
+#include <openvdb/math/FiniteDifference.h>
+#include <openvdb/tools/MeshToVolume.h>
+#include <openvdb/tools/VolumeToMesh.h>
+#include <openvdb/tools/LevelSetFilter.h>
+#include <openvdb/tools/GridTransformer.h>
+#include "openvdb_capi.h"
+
+struct OpenVDBLevelSet {
+ private:
+  openvdb::FloatGrid::Ptr grid;
+
+ public:
+  OpenVDBLevelSet();
+  ~OpenVDBLevelSet();
+  openvdb::FloatGrid::Ptr OpenVDB_level_set_get_grid();
+  void OpenVDB_level_set_set_grid(openvdb::FloatGrid::Ptr);
+  void OpenVDB_mesh_to_level_set(const float *vertices,
+                                 const unsigned int *faces,
+                                 const unsigned int totvertices,
+                                 const unsigned int totfaces,
+                                 const double voxel_size);
+
+  void OpenVDB_mesh_to_level_set(const float *vertices,
+                                 const unsigned int *faces,
+                                 const unsigned int totvertices,
+                                 const unsigned int totfaces,
+                                 openvdb::math::Transform::Ptr transform);
+
+  void OpenVDB_volume_to_mesh(float *vertices,
+                              unsigned int *quads,
+                              unsigned int *triangles,
+                              unsigned int *totvertices,
+                              unsigned int *totfaces,
+                              unsigned int *tottriangles,
+                              const double isovalue,
+                              const double adaptivity,
+                              const bool relax_disoriented_triangles);
+  void OpenVDB_volume_to_mesh(struct OpenVDBVolumeToMeshData *mesh,
+                              const double isovalue,
+                              const double adaptivity,
+                              const bool relax_disoriented_triangles);
+  void OpenVDB_level_set_filter(OpenVDBLevelSet_FilterType filter_type,
+                                int width,
+                                int iterations,
+                                int filter_bias);
+  openvdb::FloatGrid::Ptr OpenVDB_CSG_operation(openvdb::FloatGrid::Ptr gridA,
+                                                openvdb::FloatGrid::Ptr gridB,
+                                                OpenVDBLevelSet_CSGOperation operation);
+};
+
+#endif /* __OPENVDB_LEVEL_SET_H__ */

--- a/intern/openvdb/intern/openvdb_transform.cc
+++ b/intern/openvdb/intern/openvdb_transform.cc
@@ -12,26 +12,32 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) 2015 Blender Foundation.
+ * All rights reserved.
  */
-#ifndef __BKE_MBALL_TESSELLATE_H__
-#define __BKE_MBALL_TESSELLATE_H__
 
-/** \file
- * \ingroup bke
- */
-struct Depsgraph;
-struct Main;
-struct Object;
-struct Scene;
-struct Mesh;
+#include "openvdb_transform.h"
 
-void BKE_mball_polygonize(
-        struct Depsgraph *depsgraph, struct Scene *scene,
-        struct Object *ob, struct ListBase *dispbase);
+OpenVDBTransform::OpenVDBTransform()
+{
+}
 
-void BKE_mball_cubeTable_free(void);
+OpenVDBTransform::~OpenVDBTransform()
+{
+}
 
-struct Mesh* BKE_repolygonize_dm(struct Mesh *dm, float thresh, float basesize[3], float wiresize, float rendersize,
-                                 bool render, bool override_size, int defgrp_size);
+void OpenVDBTransform::OpenVDB_transform_create_linear_transform(double voxel_size)
+{
+  this->transform = openvdb::math::Transform::createLinearTransform(voxel_size);
+}
 
-#endif  /* __BKE_MBALL_TESSELLATE_H__ */
+openvdb::math::Transform::Ptr OpenVDBTransform::OpenVDB_transform_get_transform()
+{
+  return this->transform;
+}
+
+void OpenVDBTransform::OpenVDB_transform_set_transform(openvdb::math::Transform::Ptr transform)
+{
+  this->transform = transform;
+}

--- a/intern/openvdb/intern/openvdb_transform.h
+++ b/intern/openvdb/intern/openvdb_transform.h
@@ -12,26 +12,26 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) 2015 Blender Foundation.
+ * All rights reserved.
  */
-#ifndef __BKE_MBALL_TESSELLATE_H__
-#define __BKE_MBALL_TESSELLATE_H__
 
-/** \file
- * \ingroup bke
- */
-struct Depsgraph;
-struct Main;
-struct Object;
-struct Scene;
-struct Mesh;
+#ifndef OPENVDB_TRANSFORM_H
+#define OPENVDB_TRANSFORM_H
 
-void BKE_mball_polygonize(
-        struct Depsgraph *depsgraph, struct Scene *scene,
-        struct Object *ob, struct ListBase *dispbase);
+#include <openvdb/openvdb.h>
 
-void BKE_mball_cubeTable_free(void);
+struct OpenVDBTransform {
+ private:
+  openvdb::math::Transform::Ptr transform;
 
-struct Mesh* BKE_repolygonize_dm(struct Mesh *dm, float thresh, float basesize[3], float wiresize, float rendersize,
-                                 bool render, bool override_size, int defgrp_size);
+ public:
+  OpenVDBTransform();
+  ~OpenVDBTransform();
+  void OpenVDB_transform_create_linear_transform(double voxel_size);
+  openvdb::math::Transform::Ptr OpenVDB_transform_get_transform();
+  void OpenVDB_transform_set_transform(openvdb::math::Transform::Ptr transform);
+};
 
-#endif  /* __BKE_MBALL_TESSELLATE_H__ */
+#endif  // OPENVDB_TRANSFORM_H

--- a/intern/openvdb/intern/particle_tools.cpp
+++ b/intern/openvdb/intern/particle_tools.cpp
@@ -37,8 +37,8 @@ ParticleList::ParticleList(size_t size, Real rad_scale, Real vel_scale)
     : m_radius_scale(rad_scale)
     , m_velocity_scale(vel_scale)
 {
-	m_has_radius = false;
-	m_has_velocity = false;
+	m_has_radius = true;
+	m_has_velocity = true;
 	m_particle_list.reserve(size);
 }
 

--- a/intern/openvdb/openvdb_capi.cc
+++ b/intern/openvdb/openvdb_capi.cc
@@ -20,6 +20,8 @@
 #include "openvdb_capi.h"
 #include "openvdb_dense_convert.h"
 #include "openvdb_util.h"
+#include "openvdb_level_set.h"
+#include "openvdb_transform.h"
 
 /*for particle mesher modifier*/
 #include <vector>
@@ -434,4 +436,147 @@ size_t OpenVDBGeom_get_num_quads(OpenVDBGeom *geom)
 size_t OpenVDBGeom_get_num_tris(struct OpenVDBGeom *geom)
 {
 	return geom->m_tris.size();
+}
+
+OpenVDBLevelSet *OpenVDBLevelSet_create(bool initGrid, OpenVDBTransform *xform)
+{
+  OpenVDBLevelSet *level_set = new OpenVDBLevelSet();
+  if (initGrid) {
+    openvdb::FloatGrid::Ptr grid = openvdb::FloatGrid::create();
+    grid->setGridClass(openvdb::GRID_LEVEL_SET);
+    if (xform) {
+      grid->setTransform(xform->OpenVDB_transform_get_transform());
+    }
+    level_set->OpenVDB_level_set_set_grid(grid);
+  }
+  return level_set;
+}
+
+OpenVDBTransform *OpenVDBTransform_create()
+{
+  return new OpenVDBTransform();
+}
+
+void OpenVDBTransform_free(OpenVDBTransform *transform)
+{
+  delete transform;
+}
+
+void OpenVDBTransform_create_linear_transform(OpenVDBTransform *transform, double voxel_size)
+{
+  transform->OpenVDB_transform_create_linear_transform(voxel_size);
+}
+
+void OpenVDBLevelSet_free(OpenVDBLevelSet *level_set)
+{
+  delete level_set;
+}
+
+void OpenVDBLevelSet_mesh_to_level_set(struct OpenVDBLevelSet *level_set,
+                                       const float *vertices,
+                                       const unsigned int *faces,
+                                       const unsigned int totvertices,
+                                       const unsigned int totfaces,
+                                       OpenVDBTransform *xform)
+{
+  level_set->OpenVDB_mesh_to_level_set(
+      vertices, faces, totvertices, totfaces, xform->OpenVDB_transform_get_transform());
+}
+
+void OpenVDBLevelSet_mesh_to_level_set_transform(struct OpenVDBLevelSet *level_set,
+                                                 const float *vertices,
+                                                 const unsigned int *faces,
+                                                 const unsigned int totvertices,
+                                                 const unsigned int totfaces,
+                                                 struct OpenVDBTransform *transform)
+{
+  level_set->OpenVDB_mesh_to_level_set(
+      vertices, faces, totvertices, totfaces, transform->OpenVDB_transform_get_transform());
+}
+
+void OpenVDBLevelSet_volume_to_mesh(struct OpenVDBLevelSet *level_set,
+                                    struct OpenVDBVolumeToMeshData *mesh,
+                                    const double isovalue,
+                                    const double adaptivity,
+                                    const bool relax_disoriented_triangles)
+{
+  level_set->OpenVDB_volume_to_mesh(mesh, isovalue, adaptivity, relax_disoriented_triangles);
+}
+
+void OpenVDBLevelSet_filter(struct OpenVDBLevelSet *level_set,
+                            OpenVDBLevelSet_FilterType filter_type,
+                            int width,
+                            int iterations,
+                            OpenVDBLevelSet_FilterBias bias)
+{
+  level_set->OpenVDB_level_set_filter(filter_type, width, iterations, bias);
+}
+
+void OpenVDBLevelSet_CSG_operation(struct OpenVDBLevelSet *out,
+                                   struct OpenVDBLevelSet *gridA,
+                                   struct OpenVDBLevelSet *gridB,
+                                   OpenVDBLevelSet_CSGOperation operation)
+{
+  openvdb::FloatGrid::Ptr grid = out->OpenVDB_CSG_operation(
+      gridA->OpenVDB_level_set_get_grid(), gridB->OpenVDB_level_set_get_grid(), operation);
+  out->OpenVDB_level_set_set_grid(grid);
+}
+
+OpenVDBLevelSet *OpenVDBLevelSet_transform_and_resample(struct OpenVDBLevelSet *level_setA,
+                                                        struct OpenVDBLevelSet *level_setB,
+                                                        char sampler,
+                                                        float isolevel)
+{
+  openvdb::FloatGrid::Ptr sourceGrid = level_setA->OpenVDB_level_set_get_grid();
+  openvdb::FloatGrid::Ptr targetGrid = level_setB->OpenVDB_level_set_get_grid()->deepCopy();
+
+  const openvdb::math::Transform &sourceXform = sourceGrid->transform(),
+                                 &targetXform = targetGrid->transform();
+
+  // Compute a source grid to target grid transform.
+  // (For this example, we assume that both grids' transforms are linear,
+  // so that they can be represented as 4 x 4 matrices.)
+  openvdb::Mat4R xform = sourceXform.baseMap()->getAffineMap()->getMat4() *
+                         targetXform.baseMap()->getAffineMap()->getMat4().inverse();
+
+  // Create the transformer.
+  openvdb::tools::GridTransformer transformer(xform);
+
+  switch (sampler) {
+    case OPENVDB_LEVELSET_GRIDSAMPLER_POINT:
+      // Resample using nearest-neighbor interpolation.
+      transformer.transformGrid<openvdb::tools::PointSampler, openvdb::FloatGrid>(*sourceGrid,
+                                                                                  *targetGrid);
+      // Prune the target tree for optimal sparsity.
+      targetGrid->tree().prune();
+      break;
+
+    case OPENVDB_LEVELSET_GRIDSAMPLER_BOX:
+      // Resample using trilinear interpolation.
+      transformer.transformGrid<openvdb::tools::BoxSampler, openvdb::FloatGrid>(*sourceGrid,
+                                                                                *targetGrid);
+      // Prune the target tree for optimal sparsity.
+      targetGrid->tree().prune();
+      break;
+
+    case OPENVDB_LEVELSET_GRIDSAMPLER_QUADRATIC:
+      // Resample using triquadratic interpolation.
+      transformer.transformGrid<openvdb::tools::QuadraticSampler, openvdb::FloatGrid>(*sourceGrid,
+                                                                                      *targetGrid);
+      // Prune the target tree for optimal sparsity.
+      targetGrid->tree().prune();
+      break;
+
+    case OPENVDB_LEVELSET_GRIDSAMPLER_NONE:
+      // targetGrid = sourceGrid->deepCopy();
+      break;
+  }
+
+  targetGrid = openvdb::tools::levelSetRebuild(*targetGrid, isolevel, 1.0f);
+  openvdb::tools::pruneLevelSet(targetGrid->tree());
+
+  OpenVDBLevelSet *level_set = OpenVDBLevelSet_create(false, NULL);
+  level_set->OpenVDB_level_set_set_grid(targetGrid);
+
+  return level_set;
 }

--- a/intern/openvdb/openvdb_capi.h
+++ b/intern/openvdb/openvdb_capi.h
@@ -26,11 +26,78 @@
 extern "C" {
 #endif
 
+/* Level Set Filters */
+typedef enum OpenVDBLevelSet_FilterType {
+  OPENVDB_LEVELSET_FILTER_NONE = 0,
+  OPENVDB_LEVELSET_FILTER_GAUSSIAN = 1,
+  OPENVDB_LEVELSET_FILTER_MEAN = 2,
+  OPENVDB_LEVELSET_FILTER_MEDIAN = 3,
+  OPENVDB_LEVELSET_FILTER_MEAN_CURVATURE = 4,
+  OPENVDB_LEVELSET_FILTER_LAPLACIAN = 5,
+  OPENVDB_LEVELSET_FILTER_DILATE = 6,
+  OPENVDB_LEVELSET_FILTER_ERODE = 7,
+} OpenVDBLevelSet_FilterType;
+
+typedef enum OpenVDBLevelSet_FilterBias {
+  OPENVDB_LEVELSET_FIRST_BIAS = 0,
+  OPENVDB_LEVELSET_SECOND_BIAS,
+  OPENVDB_LEVELSET_THIRD_BIAS,
+  OPENVDB_LEVELSET_WENO5_BIAS,
+  OPENVDB_LEVELSET_HJWENO5_BIAS,
+} OpenVDBLevelSet_FilterBias;
+
+/* Level Set CSG Operations */
+typedef enum OpenVDBLevelSet_CSGOperation {
+  OPENVDB_LEVELSET_CSG_UNION = 0,
+  OPENVDB_LEVELSET_CSG_DIFFERENCE = 1,
+  OPENVDB_LEVELSET_CSG_INTERSECTION = 2,
+} OpenVDBLevelSet_CSGOperation;
+
+typedef enum OpenVDBLevelSet_GridSampler {
+  OPENVDB_LEVELSET_GRIDSAMPLER_NONE = 0,
+  OPENVDB_LEVELSET_GRIDSAMPLER_POINT = 1,
+  OPENVDB_LEVELSET_GRIDSAMPLER_BOX = 2,
+  OPENVDB_LEVELSET_GRIDSAMPLER_QUADRATIC = 3,
+} OpenVDBLevelSet_Gridsampler;
+
 struct OpenVDBReader;
 struct OpenVDBWriter;
+struct OpenVDBTransform;
+struct OpenVDBLevelSet;
 struct OpenVDBFloatGrid;
 struct OpenVDBIntGrid;
 struct OpenVDBVectorGrid;
+struct OpenVDBVolumeToMeshData {
+  int tottriangles;
+  int totquads;
+  int totvertices;
+
+  float *vertices;
+  unsigned int *quads;
+  unsigned int *triangles;
+};
+
+struct OpenVDBRemeshData {
+  float *verts;
+  unsigned int *faces;
+  int totfaces;
+  int totverts;
+
+  float *out_verts;
+  unsigned int *out_faces;
+  unsigned int *out_tris;
+  int out_totverts;
+  int out_totfaces;
+  int out_tottris;
+  int filter_type;
+  int filter_bias;
+  int filter_width; /*parameter for gaussian, median, mean*/
+
+  float voxel_size;
+  float isovalue;
+  float adaptivity;
+  int relax_disoriented_triangles;
+};
 
 int OpenVDB_getVersionHex(void);
 
@@ -196,6 +263,44 @@ void OpenVDB_draw_primitive(struct OpenVDBPrimitive *vdb_prim,
                             const bool draw_level_1,
                             const bool draw_level_2,
                             const bool draw_leaves);
+struct OpenVDBTransform *OpenVDBTransform_create(void);
+void OpenVDBTransform_free(struct OpenVDBTransform *transform);
+void OpenVDBTransform_create_linear_transform(struct OpenVDBTransform *transform,
+                                              double voxel_size);
+
+struct OpenVDBLevelSet *OpenVDBLevelSet_create(bool initGrid, struct OpenVDBTransform *xform);
+void OpenVDBLevelSet_free(struct OpenVDBLevelSet *level_set);
+void OpenVDBLevelSet_mesh_to_level_set(struct OpenVDBLevelSet *level_set,
+                                       const float *vertices,
+                                       const unsigned int *faces,
+                                       const unsigned int totvertices,
+                                       const unsigned int totfaces,
+                                       struct OpenVDBTransform *xform);
+void OpenVDBLevelSet_mesh_to_level_set_transform(struct OpenVDBLevelSet *level_set,
+                                                 const float *vertices,
+                                                 const unsigned int *faces,
+                                                 const unsigned int totvertices,
+                                                 const unsigned int totfaces,
+                                                 struct OpenVDBTransform *transform);
+void OpenVDBLevelSet_volume_to_mesh(struct OpenVDBLevelSet *level_set,
+                                    struct OpenVDBVolumeToMeshData *mesh,
+                                    const double isovalue,
+                                    const double adaptivity,
+                                    const bool relax_disoriented_triangles);
+void OpenVDBLevelSet_filter(struct OpenVDBLevelSet *level_set,
+                            OpenVDBLevelSet_FilterType filter_type,
+                            int width,
+                            int iterations,
+                            OpenVDBLevelSet_FilterBias bias);
+void OpenVDBLevelSet_CSG_operation(struct OpenVDBLevelSet *out,
+                                   struct OpenVDBLevelSet *gridA,
+                                   struct OpenVDBLevelSet *gridB,
+                                   OpenVDBLevelSet_CSGOperation operation);
+
+struct OpenVDBLevelSet *OpenVDBLevelSet_transform_and_resample(struct OpenVDBLevelSet *level_setA,
+                                                               struct OpenVDBLevelSet *level_setB,
+                                                               char sampler,
+                                                               float isolevel);
 
 #ifdef __cplusplus
 }

--- a/release/scripts/modules/bpy/utils/__init__.py
+++ b/release/scripts/modules/bpy/utils/__init__.py
@@ -450,12 +450,12 @@ def preset_paths(subdir):
     return dirs
 
 
-def smpte_from_seconds(time, fps=None):
+def smpte_from_seconds(time, fps=None, fps_base=None):
     """
     Returns an SMPTE formatted string from the *time*:
     ``HH:MM:SS:FF``.
 
-    If the *fps* is not given the current scene is used.
+    If *fps* and *fps_base* are not given the current scene is used.
 
     :arg time: time in seconds.
     :type time: int, float or ``datetime.timedelta``.
@@ -463,7 +463,11 @@ def smpte_from_seconds(time, fps=None):
     :rtype: string
     """
 
-    return smpte_from_frame(time_to_frame(time, fps=fps), fps)
+    return smpte_from_frame(
+        time_to_frame(time, fps=fps, fps_base=fps_base),
+        fps=fps,
+        fps_base=fps_base
+    )
 
 
 def smpte_from_frame(frame, fps=None, fps_base=None):
@@ -485,8 +489,9 @@ def smpte_from_frame(frame, fps=None, fps_base=None):
     if fps_base is None:
         fps_base = _bpy.context.scene.render.fps_base
 
+    fps = fps / fps_base
     sign = "-" if frame < 0 else ""
-    frame = abs(frame * fps_base)
+    frame = abs(frame)
 
     return (
         "%s%02d:%02d:%02d:%02d" % (
@@ -516,9 +521,11 @@ def time_from_frame(frame, fps=None, fps_base=None):
     if fps_base is None:
         fps_base = _bpy.context.scene.render.fps_base
 
+    fps = fps / fps_base
+
     from datetime import timedelta
 
-    return timedelta(0, (frame * fps_base) / fps)
+    return timedelta(0, frame / fps)
 
 
 def time_to_frame(time, fps=None, fps_base=None):
@@ -540,12 +547,14 @@ def time_to_frame(time, fps=None, fps_base=None):
     if fps_base is None:
         fps_base = _bpy.context.scene.render.fps_base
 
+    fps = fps / fps_base
+
     from datetime import timedelta
 
     if isinstance(time, timedelta):
         time = time.total_seconds()
 
-    return (time / fps_base) * fps
+    return time * fps
 
 
 def preset_find(name, preset_path, display_name=False, ext=".py"):

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -1320,7 +1320,7 @@ class WM_OT_properties_edit(Operator):
 
         row = layout.row()
         row.prop(self, "use_soft_limits")
-        if bpy.app.use_library_override:
+        if bpy.app.use_override_library:
             row.prop(self, "is_overridable_library")
 
         row = layout.row(align=True)

--- a/release/scripts/startup/bl_ui/properties_data_modifier.py
+++ b/release/scripts/startup/bl_ui/properties_data_modifier.py
@@ -1205,25 +1205,88 @@ class DATA_PT_modifiers(ModifierButtonsPanel, Panel):
         col.prop(md, "width", slider=True)
         col.prop(md, "narrowness", slider=True)
 
-    def REMESH(self, layout, _ob, md):
+    def REMESH(self, layout, ob, md):
         if not bpy.app.build_options.mod_remesh:
             layout.label(text="Built without Remesh modifier")
             return
 
         layout.prop(md, "mode")
 
-        row = layout.row()
-        row.prop(md, "octree_depth")
-        row.prop(md, "scale")
+        if md.mode not in {'VOXEL', 'METABALL'}:
+            row = layout.row()
+            row.prop(md, "octree_depth")
+            row.prop(md, "scale")
 
         if md.mode == 'SHARP':
             layout.prop(md, "sharpness")
 
-        layout.prop(md, "use_smooth_shade")
-        layout.prop(md, "use_remove_disconnected")
-        row = layout.row()
-        row.active = md.use_remove_disconnected
-        row.prop(md, "threshold")
+        if md.mode == 'VOXEL':
+            col = layout.column(align=True)
+            col.prop(md, "voxel_size")
+            col.prop(md, "isovalue")
+            col.prop(md, "adaptivity")
+            layout.prop(md, "filter_type")
+            if md.filter_type != "NONE":
+                layout.prop(md, "filter_bias")
+                if md.filter_type in {"GAUSSIAN", "MEDIAN", "MEAN"}:
+                    layout.prop(md, "filter_width")
+                if md.filter_type in {"DILATE", "ERODE"}:
+                    layout.prop(md, "filter_iterations")
+            row = layout.row()
+            row.prop(md, "live_remesh")
+            row.prop(md, "smooth_normals")
+            row = layout.row()
+            row.prop(md, "relax_triangles")
+            row.prop(md, "reproject_vertex_paint")
+            layout.label(text="CSG Operands")
+            layout.operator("remesh.csg_add", text="", icon="ADD")
+            for i,csg in enumerate(md.csg_operands):
+                box = layout.box()
+                row = box.row(align=True)
+                icon = "HIDE_ON"
+                if csg.enabled:
+                    icon = "HIDE_OFF"
+                row.prop(csg, "enabled", text="", icon=icon, emboss=True)
+                row.prop(csg, "object", text="")
+                row.prop(csg, "operation", text="")
+                row = box.row(align=True)
+                icon = "RESTRICT_VIEW_ON"
+                if csg.sync_voxel_size:
+                    icon = "RESTRICT_VIEW_OFF"
+                row.prop(csg, "use_voxel_percentage", text="", icon='CANCEL', emboss=True)
+                if not csg.use_voxel_percentage:
+                    row.prop(csg, "sync_voxel_size", text="", icon=icon, emboss=True)
+                    row.prop(csg, "voxel_size")
+                else:
+                    row.prop(csg, "voxel_percentage")
+                row.prop(csg, "sampler", text="")
+                row.operator("remesh.csg_remove", text="", icon="REMOVE").index = i
+                row.operator("remesh.csg_move_up", text="", icon="TRIA_UP").index = i
+                row.operator("remesh.csg_move_down", text="", icon="TRIA_DOWN").index = i
+        elif md.mode == 'METABALL':
+            row = layout.row()
+            row.prop(md, "input")
+            if 'PARTICLES' in md.input:
+                row = layout.row()
+                row.prop(md, "psys")
+                row = layout.row()
+                row.prop(md, "filter")
+            row = layout.row()
+            col = row.column(align=True)
+            col.prop(md, "mball_size")
+            col = row.column(align=True)
+            col.label(text="Display Parameters:")
+            col.prop(md, "mball_threshold")
+            col.prop(md, "mball_resolution")
+            col.prop(md, "mball_render_resolution")
+            layout.prop_search(md, "size_vertex_group", ob, "vertex_groups", text = "Size Vertex Group")
+            layout.prop(md, "use_smooth_shade")
+        else:
+            layout.prop(md, "use_smooth_shade")
+            layout.prop(md, "use_remove_disconnected")
+            row = layout.row()
+            row.active = md.use_remove_disconnected
+            row.prop(md, "threshold")
 
     @staticmethod
     def vertex_weight_mask(layout, ob, md):

--- a/release/scripts/startup/bl_ui/space_filebrowser.py
+++ b/release/scripts/startup/bl_ui/space_filebrowser.py
@@ -250,6 +250,11 @@ class FILEBROWSER_MT_view(Menu):
         st = context.space_data
         params = st.params
 
+        layout.prop(st, "show_region_toolbar")
+        layout.prop(st, "show_region_ui", text="File Path")
+
+        layout.separator()
+
         layout.prop_menu_enum(params, "display_size")
         layout.prop_menu_enum(params, "recursion_level")
 

--- a/source/blender/blenkernel/BKE_remesh.h
+++ b/source/blender/blenkernel/BKE_remesh.h
@@ -1,0 +1,42 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) 2001-2002 by NaN Holding BV.
+ * All rights reserved.
+ */
+#ifndef __BKE_REMESH_H__
+#define __BKE_REMESH_H__
+
+/** \file
+ * \ingroup bke
+ */
+
+#include "DNA_mesh_types.h"
+
+#include "openvdb_capi.h"
+
+/* OpenVDB Voxel Remesher */
+struct OpenVDBLevelSet *BKE_remesh_voxel_ovdb_mesh_to_level_set_create(
+    Mesh *mesh, struct OpenVDBTransform *transform);
+Mesh *BKE_remesh_voxel_ovdb_volume_to_mesh_nomain(struct OpenVDBLevelSet *level_set,
+                                                  double isovalue,
+                                                  double adaptivity,
+                                                  bool relax_disoriented_triangles);
+
+/* MLoopCol remapping based Reprojection for remesh modifier */
+MLoopCol *BKE_remesh_remap_loop_vertex_color_layer(Mesh *mesh);
+void BKE_remesh_voxel_reproject_remapped_vertex_paint(Mesh *target, Mesh *source, MLoopCol *remap);
+
+#endif /* __BKE_REMESH_H__ */

--- a/source/blender/blenkernel/CMakeLists.txt
+++ b/source/blender/blenkernel/CMakeLists.txt
@@ -177,6 +177,7 @@ set(SRC
   intern/pbvh.c
   intern/pbvh_bmesh.c
   intern/pointcache.c
+  intern/remesh_voxel.c
   intern/report.c
   intern/rigidbody.c
   intern/scene.c

--- a/source/blender/blenkernel/intern/mball_tessellate.c
+++ b/source/blender/blenkernel/intern/mball_tessellate.c
@@ -32,6 +32,8 @@
 
 #include "DNA_object_types.h"
 #include "DNA_meta_types.h"
+#include "DNA_mesh_types.h"
+#include "DNA_meshdata_types.h"
 #include "DNA_scene_types.h"
 
 #include "BLI_listbase.h"
@@ -43,7 +45,9 @@
 #include "BKE_global.h"
 
 #include "BKE_displist.h"
-#include "BKE_mball_tessellate.h" /* own include */
+#include "BKE_mball_tessellate.h"  /* own include */
+#include "BKE_mesh.h"
+#include "BKE_mesh_runtime.h"
 #include "BKE_scene.h"
 
 #include "DEG_depsgraph.h"
@@ -52,91 +56,97 @@
 #include "BLI_strict_flags.h"
 
 /* experimental (faster) normal calculation */
-// #define USE_ACCUM_NORMAL
+#define USE_ACCUM_NORMAL
+
+struct MVert;
+struct MLoop;
+struct MPoly;
 
 /* Data types */
 
-typedef struct corner { /* corner of a cube */
-  int i, j, k;          /* (i, j, k) is index within lattice */
-  float co[3], value;   /* location and function value */
-  struct corner *next;
+typedef struct corner {         /* corner of a cube */
+	int i, j, k;                /* (i, j, k) is index within lattice */
+	float co[3], value;       /* location and function value */
+	struct corner *next;
 } CORNER;
 
-typedef struct cube { /* partitioning cell (cube) */
-  int i, j, k;        /* lattice location of cube */
-  CORNER *corners[8]; /* eight corners */
+typedef struct cube {           /* partitioning cell (cube) */
+	int i, j, k, index;         /* lattice location of cube + original index ? */
+	CORNER *corners[8];         /* eight corners */
 } CUBE;
 
-typedef struct cubes { /* linked list of cubes acting as stack */
-  CUBE cube;           /* a single cube */
-  struct cubes *next;  /* remaining elements */
+typedef struct cubes {          /* linked list of cubes acting as stack */
+	CUBE cube;                  /* a single cube */
+	struct cubes *next;         /* remaining elements */
 } CUBES;
 
-typedef struct centerlist { /* list of cube locations */
-  int i, j, k;              /* cube location */
-  struct centerlist *next;  /* remaining elements */
+typedef struct centerlist {     /* list of cube locations */
+	int i, j, k;                /* cube location */
+	struct centerlist *next;    /* remaining elements */
 } CENTERLIST;
 
-typedef struct edgelist {     /* list of edges */
-  int i1, j1, k1, i2, j2, k2; /* edge corner ids */
-  int vid;                    /* vertex id */
-  struct edgelist *next;      /* remaining elements */
+typedef struct edgelist {       /* list of edges */
+	int i1, j1, k1, i2, j2, k2; /* edge corner ids */
+	int vid;                    /* vertex id */
+	struct edgelist *next;      /* remaining elements */
 } EDGELIST;
 
-typedef struct intlist { /* list of integers */
-  int i;                 /* an integer */
-  struct intlist *next;  /* remaining elements */
+typedef struct intlist {        /* list of integers */
+	int i;                      /* an integer */
+	struct intlist *next;       /* remaining elements */
 } INTLIST;
 
-typedef struct intlists { /* list of list of integers */
-  INTLIST *list;          /* a list of integers */
-  struct intlists *next;  /* remaining elements */
+typedef struct intlists {       /* list of list of integers */
+	INTLIST *list;              /* a list of integers */
+	struct intlists *next;      /* remaining elements */
 } INTLISTS;
 
-typedef struct Box { /* an AABB with pointer to metalelem */
-  float min[3], max[3];
-  const MetaElem *ml;
+typedef struct Box {			/* an AABB with pointer to metalelem */
+	float min[3], max[3];
+	const MetaElem *ml;
 } Box;
 
-typedef struct MetaballBVHNode { /* BVH node */
-  Box bb[2];                     /* AABB of children */
-  struct MetaballBVHNode *child[2];
+typedef struct MetaballBVHNode {	/* BVH node */
+	Box bb[2];						/* AABB of children */
+	struct MetaballBVHNode *child[2];
 } MetaballBVHNode;
 
-typedef struct process {     /* parameters, storage */
-  float thresh, size;        /* mball threshold, single cube size */
-  float delta;               /* small delta for calculating normals */
-  unsigned int converge_res; /* converge procedure resolution (more = slower) */
+typedef struct process {        /* parameters, storage */
+	float thresh, size;			/* mball threshold, single cube size */
+	float delta;				/* small delta for calculating normals */
+	unsigned int converge_res;	/* converge procedure resolution (more = slower) */
 
-  MetaElem **mainb;          /* array of all metaelems */
-  unsigned int totelem, mem; /* number of metaelems */
+	MetaElem **mainb;			/* array of all metaelems */
+	unsigned int totelem, mem;	/* number of metaelems */
 
-  MetaballBVHNode metaball_bvh; /* The simplest bvh */
-  Box allbb;                    /* Bounding box of all metaelems */
+	MetaballBVHNode metaball_bvh; /* The simplest bvh */
+	Box allbb;                   /* Bounding box of all metaelems */
 
-  MetaballBVHNode **bvh_queue; /* Queue used during bvh traversal */
-  unsigned int bvh_queue_size;
+	MetaballBVHNode **bvh_queue; /* Queue used during bvh traversal */
+	unsigned int bvh_queue_size;
 
-  CUBES *cubes;         /* stack of cubes waiting for polygonization */
-  CENTERLIST **centers; /* cube center hash table */
-  CORNER **corners;     /* corner value hash table */
-  EDGELIST **edges;     /* edge and vertex id hash table */
+	CUBES *cubes;               /* stack of cubes waiting for polygonization */
+	CENTERLIST **centers;       /* cube center hash table */
+	CORNER **corners;           /* corner value hash table */
+	EDGELIST **edges;           /* edge and vertex id hash table */
 
-  int (*indices)[4];     /* output indices */
-  unsigned int totindex; /* size of memory allocated for indices */
-  unsigned int curindex; /* number of currently added indices */
+	int (*indices)[4];          /* output indices */
+	unsigned int totindex;		/* size of memory allocated for indices */
+	unsigned int curindex;		/* number of currently added indices */
 
-  float (*co)[3], (*no)[3]; /* surface vertices - positions and normals */
-  unsigned int totvertex;   /* memory size */
-  unsigned int curvertex;   /* currently added vertices */
+	float (*co)[3], (*no)[3];   /* surface vertices - positions and normals */
+	unsigned int totvertex;		/* memory size */
+	unsigned int curvertex;		/* currently added vertices */
 
-  /* memory allocation from common pool */
-  MemArena *pgn_elements;
+	int* orig_index;			/* map new vertices to original ones */
+
+	/* memory allocation from common pool */
+	MemArena *pgn_elements;
 } PROCESS;
 
 /* Forward declarations */
-static int vertid(PROCESS *process, const CORNER *c1, const CORNER *c2);
-static void add_cube(PROCESS *process, int i, int j, int k);
+static int vertid(PROCESS *process, const CORNER *c1, const CORNER *c2, int index);
+static void add_cube(PROCESS *process, int i, int j, int k, int index);
 static void make_face(PROCESS *process, int i1, int i2, int i3, int i4);
 static void converge(PROCESS *process, const CORNER *c1, const CORNER *c2, float r_p[3]);
 
@@ -609,22 +619,22 @@ static void docube(PROCESS *process, CUBE *cube)
 
   /* Using faces[] table, adds neighbouring cube if surface intersects face in this direction. */
   if (MB_BIT(faces[index], 0)) {
-    add_cube(process, cube->i - 1, cube->j, cube->k);
+    add_cube(process, cube->i - 1, cube->j, cube->k, cube->index);
   }
   if (MB_BIT(faces[index], 1)) {
-    add_cube(process, cube->i + 1, cube->j, cube->k);
+    add_cube(process, cube->i + 1, cube->j, cube->k, cube->index);
   }
   if (MB_BIT(faces[index], 2)) {
-    add_cube(process, cube->i, cube->j - 1, cube->k);
+    add_cube(process, cube->i, cube->j - 1, cube->k, cube->index);
   }
   if (MB_BIT(faces[index], 3)) {
-    add_cube(process, cube->i, cube->j + 1, cube->k);
+    add_cube(process, cube->i, cube->j + 1, cube->k, cube->index);
   }
   if (MB_BIT(faces[index], 4)) {
-    add_cube(process, cube->i, cube->j, cube->k - 1);
+    add_cube(process, cube->i, cube->j, cube->k - 1, cube->index);
   }
   if (MB_BIT(faces[index], 5)) {
-    add_cube(process, cube->i, cube->j, cube->k + 1);
+    add_cube(process, cube->i, cube->j, cube->k + 1, cube->index);
   }
 
   /* Using cubetable[], determines polygons for output. */
@@ -637,7 +647,7 @@ static void docube(PROCESS *process, CUBE *cube)
       c1 = cube->corners[corner1[edges->i]];
       c2 = cube->corners[corner2[edges->i]];
 
-      indexar[count] = vertid(process, c1, c2);
+      indexar[count] = vertid(process, c1, c2, cube->index);
       count++;
     }
 
@@ -947,16 +957,18 @@ static int getedge(EDGELIST *table[], int i1, int j1, int k1, int i2, int j2, in
 /**
  * Adds a vertex, expands memory if needed.
  */
-static void addtovertices(PROCESS *process, const float v[3], const float no[3])
+static void addtovertices(PROCESS *process, const float v[3], const float no[3], int index)
 {
   if (process->curvertex == process->totvertex) {
     process->totvertex += 4096;
     process->co = MEM_reallocN(process->co, process->totvertex * sizeof(float[3]));
     process->no = MEM_reallocN(process->no, process->totvertex * sizeof(float[3]));
+    process->orig_index = MEM_reallocN(process->orig_index, process->totvertex * sizeof(int));
   }
 
   copy_v3_v3(process->co[process->curvertex], v);
   copy_v3_v3(process->no[process->curvertex], no);
+  process->orig_index[process->curvertex] = index;
 
   process->curvertex++;
 }
@@ -983,7 +995,7 @@ static void vnormal(PROCESS *process, const float point[3], float r_no[3])
  *
  * If it wasn't previously computed, does #converge() and adds vertex to process.
  */
-static int vertid(PROCESS *process, const CORNER *c1, const CORNER *c2)
+static int vertid(PROCESS *process, const CORNER *c1, const CORNER *c2, int index)
 {
   float v[3], no[3];
   int vid = getedge(process->edges, c1->i, c1->j, c1->k, c2->i, c2->j, c2->k);
@@ -1000,7 +1012,7 @@ static int vertid(PROCESS *process, const CORNER *c1, const CORNER *c2)
   vnormal(process, v, no);
 #endif
 
-  addtovertices(process, v, no); /* save vertex */
+  addtovertices(process, v, no, index); /* save vertex */
   vid = (int)process->curvertex - 1;
   setedge(process, c1->i, c1->j, c1->k, c2->i, c2->j, c2->k, vid);
 
@@ -1052,7 +1064,7 @@ static void converge(PROCESS *process, const CORNER *c1, const CORNER *c2, float
 /**
  * Adds cube at given lattice position to cube stack of process.
  */
-static void add_cube(PROCESS *process, int i, int j, int k)
+static void add_cube(PROCESS *process, int i, int j, int k, int index)
 {
   CUBES *ncube;
   int n;
@@ -1067,6 +1079,7 @@ static void add_cube(PROCESS *process, int i, int j, int k)
     ncube->cube.i = i;
     ncube->cube.j = j;
     ncube->cube.k = k;
+    ncube->cube.index = index;
 
     /* set corners of initial cube: */
     for (n = 0; n < 8; n++) {
@@ -1134,7 +1147,7 @@ static void find_first_points(PROCESS *process, const unsigned int em)
             add[1] = it[1] - dir[1];
             add[2] = it[2] - dir[2];
             DO_MIN(it, add);
-            add_cube(process, add[0], add[1], add[2]);
+            add_cube(process, add[0], add[1], add[2], (int)em);
             break;
           }
         } while ((it[0] > lbn[0]) && (it[1] > lbn[1]) && (it[2] > lbn[2]) && (it[0] < rtf[0]) &&
@@ -1181,284 +1194,575 @@ static void polygonize(PROCESS *process)
  * Computes bounding boxes for building BVH. */
 static void init_meta(Depsgraph *depsgraph, PROCESS *process, Scene *scene, Object *ob)
 {
-  Scene *sce_iter = scene;
-  Base *base;
-  Object *bob;
-  MetaBall *mb;
-  const MetaElem *ml;
-  float obinv[4][4], obmat[4][4];
-  unsigned int i;
-  int obnr, zero_size = 0;
-  char obname[MAX_ID_NAME];
-  SceneBaseIter iter;
+	Scene *sce_iter = scene;
+	Base *base;
+	Object *bob;
+	MetaBall *mb;
+	const MetaElem *ml;
+	float obinv[4][4], obmat[4][4];
+	unsigned int i;
+	int obnr, zero_size = 0;
+	char obname[MAX_ID_NAME];
+	SceneBaseIter iter;
 
-  copy_m4_m4(obmat, ob->obmat); /* to cope with duplicators from BKE_scene_base_iter_next */
-  invert_m4_m4(obinv, ob->obmat);
+	copy_m4_m4(obmat, ob->obmat);   /* to cope with duplicators from BKE_scene_base_iter_next */
+	invert_m4_m4(obinv, ob->obmat);
 
-  BLI_split_name_num(obname, &obnr, ob->id.name + 2, '.');
+	BLI_split_name_num(obname, &obnr, ob->id.name + 2, '.');
 
-  /* make main array */
-  BKE_scene_base_iter_next(depsgraph, &iter, &sce_iter, 0, NULL, NULL);
-  while (BKE_scene_base_iter_next(depsgraph, &iter, &sce_iter, 1, &base, &bob)) {
-    if (bob->type == OB_MBALL) {
-      zero_size = 0;
-      ml = NULL;
+	/* make main array */
+	BKE_scene_base_iter_next(depsgraph, &iter, &sce_iter, 0, NULL, NULL);
+	while (BKE_scene_base_iter_next(depsgraph, &iter, &sce_iter, 1, &base, &bob)) {
+		if (bob->type == OB_MBALL) {
+			zero_size = 0;
+			ml = NULL;
 
-      if (bob == ob && (base->flag_legacy & OB_FROMDUPLI) == 0) {
-        mb = ob->data;
+			if (bob == ob && (base->flag_legacy & OB_FROMDUPLI) == 0) {
+				mb = ob->data;
 
-        if (mb->editelems) {
-          ml = mb->editelems->first;
-        }
-        else {
-          ml = mb->elems.first;
-        }
-      }
-      else {
-        char name[MAX_ID_NAME];
-        int nr;
+				if (mb->editelems) ml = mb->editelems->first;
+				else ml = mb->elems.first;
+			}
+			else {
+				char name[MAX_ID_NAME];
+				int nr;
 
-        BLI_split_name_num(name, &nr, bob->id.name + 2, '.');
-        if (STREQ(obname, name)) {
-          mb = bob->data;
+				BLI_split_name_num(name, &nr, bob->id.name + 2, '.');
+				if (STREQ(obname, name)) {
+					mb = bob->data;
 
-          if (mb->editelems) {
-            ml = mb->editelems->first;
-          }
-          else {
-            ml = mb->elems.first;
-          }
-        }
-      }
+					if (mb->editelems) ml = mb->editelems->first;
+					else ml = mb->elems.first;
+				}
+			}
 
-      /* when metaball object has zero scale, then MetaElem to this MetaBall
-       * will not be put to mainb array */
-      if (has_zero_axis_m4(bob->obmat)) {
-        zero_size = 1;
-      }
-      else if (bob->parent) {
-        struct Object *pob = bob->parent;
-        while (pob) {
-          if (has_zero_axis_m4(pob->obmat)) {
-            zero_size = 1;
-            break;
-          }
-          pob = pob->parent;
-        }
-      }
+			/* when metaball object has zero scale, then MetaElem to this MetaBall
+			 * will not be put to mainb array */
+			if (has_zero_axis_m4(bob->obmat)) {
+				zero_size = 1;
+			}
+			else if (bob->parent) {
+				struct Object *pob = bob->parent;
+				while (pob) {
+					if (has_zero_axis_m4(pob->obmat)) {
+						zero_size = 1;
+						break;
+					}
+					pob = pob->parent;
+				}
+			}
 
-      if (zero_size) {
-        while (ml) {
-          ml = ml->next;
-        }
-      }
-      else {
-        while (ml) {
-          if (!(ml->flag & MB_HIDE)) {
-            float pos[4][4], rot[4][4];
-            float expx, expy, expz;
-            float tempmin[3], tempmax[3];
+			if (zero_size) {
+				while (ml) {
+					ml = ml->next;
+				}
+			}
+			else {
+				while (ml) {
+					if (!(ml->flag & MB_HIDE)) {
+						float pos[4][4], rot[4][4];
+						float expx, expy, expz;
+						float tempmin[3], tempmax[3];
 
-            MetaElem *new_ml;
+						MetaElem *new_ml;
 
-            /* make a copy because of duplicates */
-            new_ml = BLI_memarena_alloc(process->pgn_elements, sizeof(MetaElem));
-            *(new_ml) = *ml;
-            new_ml->bb = BLI_memarena_alloc(process->pgn_elements, sizeof(BoundBox));
-            new_ml->mat = BLI_memarena_alloc(process->pgn_elements, 4 * 4 * sizeof(float));
-            new_ml->imat = BLI_memarena_alloc(process->pgn_elements, 4 * 4 * sizeof(float));
+						/* make a copy because of duplicates */
+						new_ml = BLI_memarena_alloc(process->pgn_elements, sizeof(MetaElem));
+						*(new_ml) = *ml;
+						new_ml->bb = BLI_memarena_alloc(process->pgn_elements, sizeof(BoundBox));
+						new_ml->mat = BLI_memarena_alloc(process->pgn_elements, 4 * 4 * sizeof(float));
+						new_ml->imat = BLI_memarena_alloc(process->pgn_elements, 4 * 4 * sizeof(float));
 
-            /* too big stiffness seems only ugly due to linear interpolation
-             * no need to have possibility for too big stiffness */
-            if (ml->s > 10.0f) {
-              new_ml->s = 10.0f;
-            }
-            else {
-              new_ml->s = ml->s;
-            }
+						/* too big stiffness seems only ugly due to linear interpolation
+						 * no need to have possibility for too big stiffness */
+						if (ml->s > 10.0f) new_ml->s = 10.0f;
+						else new_ml->s = ml->s;
 
-            /* if metaball is negative, set stiffness negative */
-            if (new_ml->flag & MB_NEGATIVE) {
-              new_ml->s = -new_ml->s;
-            }
+						/* if metaball is negative, set stiffness negative */
+						if (new_ml->flag & MB_NEGATIVE) new_ml->s = -new_ml->s;
 
-            /* Translation of MetaElem */
-            unit_m4(pos);
-            pos[3][0] = ml->x;
-            pos[3][1] = ml->y;
-            pos[3][2] = ml->z;
+						/* Translation of MetaElem */
+						unit_m4(pos);
+						pos[3][0] = ml->x;
+						pos[3][1] = ml->y;
+						pos[3][2] = ml->z;
 
-            /* Rotation of MetaElem is stored in quat */
-            quat_to_mat4(rot, ml->quat);
+						/* Rotation of MetaElem is stored in quat */
+						quat_to_mat4(rot, ml->quat);
 
-            /* Matrix multiply is as follows:
-             *   basis object space ->
-             *   world ->
-             *   ml object space ->
-             *   position ->
-             *   rotation ->
-             *   ml local space
-             */
-            mul_m4_series((float(*)[4])new_ml->mat, obinv, bob->obmat, pos, rot);
-            /* ml local space -> basis object space */
-            invert_m4_m4((float(*)[4])new_ml->imat, (float(*)[4])new_ml->mat);
+						/* basis object space -> world -> ml object space -> position -> rotation -> ml local space */
+						mul_m4_series((float(*)[4])new_ml->mat, obinv, bob->obmat, pos, rot);
+						/* ml local space -> basis object space */
+						invert_m4_m4((float(*)[4])new_ml->imat, (float(*)[4])new_ml->mat);
 
-            /* rad2 is inverse of squared radius */
-            new_ml->rad2 = 1 / (ml->rad * ml->rad);
+						/* rad2 is inverse of squared radius */
+						new_ml->rad2 = 1 / (ml->rad * ml->rad);
 
-            /* initial dimensions = radius */
-            expx = ml->rad;
-            expy = ml->rad;
-            expz = ml->rad;
+						/* initial dimensions = radius */
+						expx = ml->rad;
+						expy = ml->rad;
+						expz = ml->rad;
 
-            switch (ml->type) {
-              case MB_BALL:
-                break;
-              case MB_CUBE: /* cube is "expanded" by expz, expy and expx */
-                expz += ml->expz;
-                ATTR_FALLTHROUGH;
-              case MB_PLANE: /* plane is "expanded" by expy and expx */
-                expy += ml->expy;
-                ATTR_FALLTHROUGH;
-              case MB_TUBE: /* tube is "expanded" by expx */
-                expx += ml->expx;
-                break;
-              case MB_ELIPSOID: /* ellipsoid is "stretched" by exp* */
-                expx *= ml->expx;
-                expy *= ml->expy;
-                expz *= ml->expz;
-                break;
-            }
+						switch (ml->type) {
+							case MB_BALL:
+								break;
+							case MB_CUBE: /* cube is "expanded" by expz, expy and expx */
+								expz += ml->expz;
+								ATTR_FALLTHROUGH;
+							case MB_PLANE: /* plane is "expanded" by expy and expx */
+								expy += ml->expy;
+								ATTR_FALLTHROUGH;
+							case MB_TUBE: /* tube is "expanded" by expx */
+								expx += ml->expx;
+								break;
+							case MB_ELIPSOID: /* ellipsoid is "stretched" by exp* */
+								expx *= ml->expx;
+								expy *= ml->expy;
+								expz *= ml->expz;
+								break;
+						}
 
-            /* untransformed Bounding Box of MetaElem */
-            /* TODO, its possible the elem type has been changed and the exp*
-             * values can use a fallback. */
-            copy_v3_fl3(new_ml->bb->vec[0], -expx, -expy, -expz); /* 0 */
-            copy_v3_fl3(new_ml->bb->vec[1], +expx, -expy, -expz); /* 1 */
-            copy_v3_fl3(new_ml->bb->vec[2], +expx, +expy, -expz); /* 2 */
-            copy_v3_fl3(new_ml->bb->vec[3], -expx, +expy, -expz); /* 3 */
-            copy_v3_fl3(new_ml->bb->vec[4], -expx, -expy, +expz); /* 4 */
-            copy_v3_fl3(new_ml->bb->vec[5], +expx, -expy, +expz); /* 5 */
-            copy_v3_fl3(new_ml->bb->vec[6], +expx, +expy, +expz); /* 6 */
-            copy_v3_fl3(new_ml->bb->vec[7], -expx, +expy, +expz); /* 7 */
+						/* untransformed Bounding Box of MetaElem */
+						/* TODO, its possible the elem type has been changed and the exp* values can use a fallback */
+						copy_v3_fl3(new_ml->bb->vec[0], -expx, -expy, -expz);  /* 0 */
+						copy_v3_fl3(new_ml->bb->vec[1], +expx, -expy, -expz);  /* 1 */
+						copy_v3_fl3(new_ml->bb->vec[2], +expx, +expy, -expz);  /* 2 */
+						copy_v3_fl3(new_ml->bb->vec[3], -expx, +expy, -expz);  /* 3 */
+						copy_v3_fl3(new_ml->bb->vec[4], -expx, -expy, +expz);  /* 4 */
+						copy_v3_fl3(new_ml->bb->vec[5], +expx, -expy, +expz);  /* 5 */
+						copy_v3_fl3(new_ml->bb->vec[6], +expx, +expy, +expz);  /* 6 */
+						copy_v3_fl3(new_ml->bb->vec[7], -expx, +expy, +expz);  /* 7 */
 
-            /* transformation of Metalem bb */
-            for (i = 0; i < 8; i++) {
-              mul_m4_v3((float(*)[4])new_ml->mat, new_ml->bb->vec[i]);
-            }
+						/* transformation of Metalem bb */
+						for (i = 0; i < 8; i++)
+							mul_m4_v3((float(*)[4])new_ml->mat, new_ml->bb->vec[i]);
 
-            /* find max and min of transformed bb */
-            INIT_MINMAX(tempmin, tempmax);
-            for (i = 0; i < 8; i++) {
-              DO_MINMAX(new_ml->bb->vec[i], tempmin, tempmax);
-            }
+						/* find max and min of transformed bb */
+						INIT_MINMAX(tempmin, tempmax);
+						for (i = 0; i < 8; i++) {
+							DO_MINMAX(new_ml->bb->vec[i], tempmin, tempmax);
+						}
 
-            /* set only point 0 and 6 - AABB of Metaelem */
-            copy_v3_v3(new_ml->bb->vec[0], tempmin);
-            copy_v3_v3(new_ml->bb->vec[6], tempmax);
+						/* set only point 0 and 6 - AABB of Metaelem */
+						copy_v3_v3(new_ml->bb->vec[0], tempmin);
+						copy_v3_v3(new_ml->bb->vec[6], tempmax);
 
-            /* add new_ml to mainb[] */
-            if (UNLIKELY(process->totelem == process->mem)) {
-              process->mem = process->mem * 2 + 10;
-              process->mainb = MEM_reallocN(process->mainb, sizeof(MetaElem *) * process->mem);
-            }
-            process->mainb[process->totelem++] = new_ml;
-          }
-          ml = ml->next;
-        }
-      }
-    }
-  }
+						/* add new_ml to mainb[] */
+						if (UNLIKELY(process->totelem == process->mem)) {
+							process->mem = process->mem * 2 + 10;
+							process->mainb = MEM_reallocN(process->mainb, sizeof(MetaElem *) * process->mem);
+						}
+						process->mainb[process->totelem++] = new_ml;
+					}
+					ml = ml->next;
+				}
+			}
+		}
+	}
 
-  /* compute AABB of all Metaelems */
-  if (process->totelem > 0) {
-    copy_v3_v3(process->allbb.min, process->mainb[0]->bb->vec[0]);
-    copy_v3_v3(process->allbb.max, process->mainb[0]->bb->vec[6]);
-    for (i = 1; i < process->totelem; i++) {
-      make_box_union(process->mainb[i]->bb, &process->allbb, &process->allbb);
-    }
-  }
+	/* compute AABB of all Metaelems */
+	if (process->totelem > 0) {
+		copy_v3_v3(process->allbb.min, process->mainb[0]->bb->vec[0]);
+		copy_v3_v3(process->allbb.max, process->mainb[0]->bb->vec[6]);
+		for (i = 1; i < process->totelem; i++)
+			make_box_union(process->mainb[i]->bb, &process->allbb, &process->allbb);
+	}
 }
 
 void BKE_mball_polygonize(Depsgraph *depsgraph, Scene *scene, Object *ob, ListBase *dispbase)
 {
-  MetaBall *mb;
-  DispList *dl;
-  unsigned int a;
-  PROCESS process = {0};
-  bool is_render = DEG_get_mode(depsgraph) == DAG_EVAL_RENDER;
+	MetaBall *mb;
+	DispList *dl;
+	unsigned int a;
+	PROCESS process = {0};
+	bool is_render = DEG_get_mode(depsgraph) == DAG_EVAL_RENDER;
 
-  mb = ob->data;
+	mb = ob->data;
 
-  process.thresh = mb->thresh;
+	process.thresh = mb->thresh;
 
-  if (process.thresh < 0.001f) {
-    process.converge_res = 16;
-  }
-  else if (process.thresh < 0.01f) {
-    process.converge_res = 8;
-  }
-  else if (process.thresh < 0.1f) {
-    process.converge_res = 4;
-  }
-  else {
-    process.converge_res = 2;
-  }
+	if      (process.thresh < 0.001f) process.converge_res = 16;
+	else if (process.thresh < 0.01f)  process.converge_res = 8;
+	else if (process.thresh < 0.1f)   process.converge_res = 4;
+	else                              process.converge_res = 2;
 
-  if (is_render && (mb->flag == MB_UPDATE_NEVER)) {
-    return;
-  }
-  if ((G.moving & (G_TRANSFORM_OBJ | G_TRANSFORM_EDIT)) && mb->flag == MB_UPDATE_FAST) {
-    return;
-  }
+	if (is_render && (mb->flag == MB_UPDATE_NEVER)) return;
+	if ((G.moving & (G_TRANSFORM_OBJ | G_TRANSFORM_EDIT)) && mb->flag == MB_UPDATE_FAST) return;
 
-  if (is_render) {
-    process.size = mb->rendersize;
-  }
-  else {
-    process.size = mb->wiresize;
-    if ((G.moving & (G_TRANSFORM_OBJ | G_TRANSFORM_EDIT)) && mb->flag == MB_UPDATE_HALFRES) {
-      process.size *= 2.0f;
-    }
-  }
+	if (is_render) {
+		process.size = mb->rendersize;
+	}
+	else {
+		process.size = mb->wiresize;
+		if ((G.moving & (G_TRANSFORM_OBJ | G_TRANSFORM_EDIT)) && mb->flag == MB_UPDATE_HALFRES) {
+			process.size *= 2.0f;
+		}
+	}
 
-  process.delta = process.size * 0.001f;
+	process.delta = process.size * 0.001f;
 
-  process.pgn_elements = BLI_memarena_new(BLI_MEMARENA_STD_BUFSIZE, "Metaball memarena");
+	process.pgn_elements = BLI_memarena_new(BLI_MEMARENA_STD_BUFSIZE, "Metaball memarena");
 
-  /* initialize all mainb (MetaElems) */
-  init_meta(depsgraph, &process, scene, ob);
+	/* initialize all mainb (MetaElems) */
+	init_meta(depsgraph, &process, scene, ob);
 
-  if (process.totelem > 0) {
-    build_bvh_spatial(&process, &process.metaball_bvh, 0, process.totelem, &process.allbb);
+	if (process.totelem > 0) {
+		build_bvh_spatial(&process, &process.metaball_bvh, 0, process.totelem, &process.allbb);
 
-    /* Don't polygonize metaballs with too high resolution (base mball to small)
-     * note: Eps was 0.0001f but this was giving problems for blood animation for durian,
-     * using 0.00001f. */
-    if (ob->scale[0] > 0.00001f * (process.allbb.max[0] - process.allbb.min[0]) ||
-        ob->scale[1] > 0.00001f * (process.allbb.max[1] - process.allbb.min[1]) ||
-        ob->scale[2] > 0.00001f * (process.allbb.max[2] - process.allbb.min[2])) {
-      polygonize(&process);
+		/* don't polygonize metaballs with too high resolution (base mball to small)
+		 * note: Eps was 0.0001f but this was giving problems for blood animation for durian, using 0.00001f */
+		if (ob->scale[0] > 0.00001f * (process.allbb.max[0] - process.allbb.min[0]) ||
+		    ob->scale[1] > 0.00001f * (process.allbb.max[1] - process.allbb.min[1]) ||
+		    ob->scale[2] > 0.00001f * (process.allbb.max[2] - process.allbb.min[2]))
+		{
+			polygonize(&process);
 
-      /* add resulting surface to displist */
-      if (process.curindex) {
-        dl = MEM_callocN(sizeof(DispList), "mballdisp");
-        BLI_addtail(dispbase, dl);
-        dl->type = DL_INDEX4;
-        dl->nr = (int)process.curvertex;
-        dl->parts = (int)process.curindex;
+			/* add resulting surface to displist */
+			if (process.curindex) {
+				dl = MEM_callocN(sizeof(DispList), "mballdisp");
+				BLI_addtail(dispbase, dl);
+				dl->type = DL_INDEX4;
+				dl->nr = (int)process.curvertex;
+				dl->parts = (int)process.curindex;
 
-        dl->index = (int *)process.indices;
+				dl->index = (int *)process.indices;
 
-        for (a = 0; a < process.curvertex; a++) {
-          normalize_v3(process.no[a]);
-        }
+				for (a = 0; a < process.curvertex; a++) {
+					normalize_v3(process.no[a]);
+				}
 
-        dl->verts = (float *)process.co;
-        dl->nors = (float *)process.no;
-      }
-    }
-  }
+				dl->verts = (float *)process.co;
+				dl->nors = (float *)process.no;
+			}
+		}
+	}
 
-  freepolygonize(&process);
+	freepolygonize(&process);
+}
+
+static void init_meta_dm(PROCESS* process, Mesh *dm, float stiffness, float radius, float size[3],
+                         bool override_size, int defgrp_size)
+{
+	float quat[4];
+	unsigned int i;
+	int totvert = dm->totvert, j;
+	MVert* mvert = dm->mvert;
+	float* psize = CustomData_get_layer_named(&dm->vdata, CD_PROP_FLT, "psize");
+	MDeformVert *dvert = CustomData_get_layer(&dm->vdata, CD_MDEFORMVERT);
+
+	unit_qt(quat);
+
+	/* make main array */
+	for (j = 0; j < totvert; j++, mvert++)
+	{
+		MetaElem *new_ml;
+
+		//float size[3] = {1.0f, 1.0f, 1.0f};
+		float expx, expy, expz;
+		float tempmin[3], tempmax[3];
+		float sz[3];
+
+		if (psize != NULL && psize[j] > 0.0f && override_size)
+		{
+			mul_v3_v3fl(sz, size, psize[j]);
+		}
+		else {
+			copy_v3_v3(sz, size);
+		}
+
+		/* make a copy because of duplicates */
+		new_ml = BLI_memarena_alloc(process->pgn_elements, sizeof(MetaElem));
+		new_ml->bb = BLI_memarena_alloc(process->pgn_elements, sizeof(BoundBox));
+		new_ml->mat = BLI_memarena_alloc(process->pgn_elements, 4 * 4 * sizeof(float));
+		new_ml->imat = BLI_memarena_alloc(process->pgn_elements, 4 * 4 * sizeof(float));
+
+		//init new_ml
+		new_ml->type = MB_BALL;
+		new_ml->flag = MB_SCALE_RAD;
+		/* too big stiffness seems only ugly due to linear interpolation
+		 * no need to have possibility for too big stiffness */
+		//if (ml->s > 10.0f) new_ml->s = 10.0f;
+		//else new_ml->s = ml->s;
+		new_ml->s = stiffness;
+
+		/* if metaball is negative, set stiffness negative */
+		//if (new_ml->flag & MB_NEGATIVE) new_ml->s = -new_ml->s;
+
+		if (dvert && defgrp_size > -1)
+		{
+			MDeformVert *dv = dvert + j;
+			if (dv && dv->dw)
+			{
+				float w = dv->dw[defgrp_size].weight - 0.5f;
+				//map 0..1 weights to -0.5f ... + 0.5f size factor, to allow also negative sizes... 0.5f weight is 0 size
+				mul_v3_fl(sz, w);
+
+				/* if metaball is negative, set stiffness negative, indicated by weight < 0.5f here */
+				if (w < 0.5f)
+				{
+					new_ml->s = -new_ml->s;
+				}
+			}
+		}
+
+		/* Translation of MetaElem */
+		/*unit_m4(pos);
+		pos[3][0] = mvert->co[0];
+		pos[3][1] = mvert->co[1];
+		pos[3][2] = mvert->co[2];*/
+
+		new_ml->x = mvert->co[0];
+		new_ml->y = mvert->co[1];
+		new_ml->z = mvert->co[2];
+
+		/* Rotation of MetaElem is stored in quat */
+		//quat_to_mat4(rot, quat);
+
+
+		loc_quat_size_to_mat4((float(*)[4])new_ml->mat, mvert->co, quat, sz);
+		invert_m4_m4((float(*)[4])new_ml->imat,(float(*)[4])new_ml->mat);
+
+#if 0
+		/* basis object space -> world -> ml object space -> position -> rotation -> ml local space */
+		mul_m4_series((float(*)[4])new_ml->mat, obinv, bob->obmat, pos, rot);
+		/* ml local space -> basis object space */
+		invert_m4_m4((float(*)[4])new_ml->imat, (float(*)[4])new_ml->mat);
+#endif
+
+		/* rad2 is inverse of squared radius */
+		new_ml->rad = radius;
+		new_ml->rad2 = 1 / (radius * radius);
+
+		/* initial dimensions = radius */
+		expx = radius;
+		expy = radius;
+		expz = radius;
+
+		new_ml->expx = expx;
+		new_ml->expy = expy;
+		new_ml->expz = expz;
+
+#if 0
+		switch (ml->type) {
+			case MB_BALL:
+				break;
+			case MB_CUBE: /* cube is "expanded" by expz, expy and expx */
+				expz += ml->expz;
+				ATTR_FALLTHROUGH;
+			case MB_PLANE: /* plane is "expanded" by expy and expx */
+				expy += ml->expy;
+				ATTR_FALLTHROUGH;
+			case MB_TUBE: /* tube is "expanded" by expx */
+				expx += ml->expx;
+				break;
+			case MB_ELIPSOID: /* ellipsoid is "stretched" by exp* */
+				expx *= ml->expx;
+				expy *= ml->expy;
+				expz *= ml->expz;
+				break;
+		}
+#endif
+
+		/* untransformed Bounding Box of MetaElem */
+		/* TODO, its possible the elem type has been changed and the exp* values can use a fallback */
+		copy_v3_fl3(new_ml->bb->vec[0], -expx, -expy, -expz);  /* 0 */
+		copy_v3_fl3(new_ml->bb->vec[1], +expx, -expy, -expz);  /* 1 */
+		copy_v3_fl3(new_ml->bb->vec[2], +expx, +expy, -expz);  /* 2 */
+		copy_v3_fl3(new_ml->bb->vec[3], -expx, +expy, -expz);  /* 3 */
+		copy_v3_fl3(new_ml->bb->vec[4], -expx, -expy, +expz);  /* 4 */
+		copy_v3_fl3(new_ml->bb->vec[5], +expx, -expy, +expz);  /* 5 */
+		copy_v3_fl3(new_ml->bb->vec[6], +expx, +expy, +expz);  /* 6 */
+		copy_v3_fl3(new_ml->bb->vec[7], -expx, +expy, +expz);  /* 7 */
+
+		/* transformation of Metalem bb */
+		for (i = 0; i < 8; i++)
+			mul_m4_v3((float(*)[4])new_ml->mat, new_ml->bb->vec[i]);
+
+		/* find max and min of transformed bb */
+		INIT_MINMAX(tempmin, tempmax);
+		for (i = 0; i < 8; i++) {
+			DO_MINMAX(new_ml->bb->vec[i], tempmin, tempmax);
+		}
+
+		/* set only point 0 and 6 - AABB of Metaelem */
+		copy_v3_v3(new_ml->bb->vec[0], tempmin);
+		copy_v3_v3(new_ml->bb->vec[6], tempmax);
+
+		/* add new_ml to mainb[] */
+		if (UNLIKELY(process->totelem == process->mem)) {
+			process->mem = process->mem * 2 + 10;
+			process->mainb = MEM_reallocN(process->mainb, sizeof(MetaElem *) * process->mem);
+		}
+		process->mainb[process->totelem++] = new_ml;
+	}
+
+	/* compute AABB of all Metaelems */
+	if (process->totelem > 0) {
+		copy_v3_v3(process->allbb.min, process->mainb[0]->bb->vec[0]);
+		copy_v3_v3(process->allbb.max, process->mainb[0]->bb->vec[6]);
+		for (i = 1; i < process->totelem; i++)
+			make_box_union(process->mainb[i]->bb, &process->allbb, &process->allbb);
+	}
+}
+
+void BKE_dm_from_metaball(DispList *dl, Mesh *dm, Mesh *odm, int *orig_index)
+{
+	MVert *mvert;
+	MLoop *mloop, *allloop;
+	MPoly *mpoly;
+	const float *nors, *verts;
+	float *velX, *velY, *velZ, *ovX = NULL, *ovY = NULL, *ovZ = NULL;
+	int a, *index;
+	int totvert = 0;
+
+	if (dl == NULL) return;
+
+	if (dl->type == DL_INDEX4) {
+		totvert = dm->totvert;
+		mvert = dm->mvert;
+		allloop = mloop = dm->mloop;
+		mpoly = dm->mpoly;
+
+		velX = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, totvert, "velX");
+		velY = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, totvert, "velY");
+		velZ = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, totvert, "velZ");
+
+		ovX = CustomData_get_layer_named(&odm->vdata, CD_PROP_FLT, "velX");
+		ovY = CustomData_get_layer_named(&odm->vdata, CD_PROP_FLT, "velY");
+		ovZ = CustomData_get_layer_named(&odm->vdata, CD_PROP_FLT, "velZ");
+
+		//this will be recalculated here
+		dm->totloop = 0;
+
+		a = dl->nr;
+		nors = dl->nors;
+		verts = dl->verts;
+		while (a--) {
+			copy_v3_v3(mvert->co, verts);
+			normal_float_to_short_v3(mvert->no, nors);
+			mvert++;
+			nors += 3;
+			verts += 3;
+		}
+
+		a = dl->parts;
+		index = dl->index;
+		while (a--) {
+			int k = 0;
+			int count = index[2] != index[3] ? 4 : 3;
+
+			mloop[0].v = (unsigned int)index[0];
+			mloop[1].v = (unsigned int)index[1];
+			mloop[2].v = (unsigned int) index[2];
+			if (count == 4)
+				mloop[3].v = (unsigned int)index[3];
+
+			mpoly->totloop = count;
+			mpoly->loopstart = (int)(mloop - allloop);
+			//mpoly->flag = ME_SMOOTH;
+
+			for (k = 0; k < count; k++)
+			{
+				if (ovX && ovY && ovZ)
+				{
+					int v = index[k];
+					velX[v] = ovX[orig_index[v]];
+					velY[v] = ovY[orig_index[v]];
+					velZ[v] = ovZ[orig_index[v]];
+					//printf("Vel %f %f %f/n", velX[a], velY[a], velZ[a]);
+				}
+			}
+
+
+			mpoly++;
+			mloop += count;
+			dm->totloop += count;
+			index += 4;
+		}
+
+		BKE_mesh_calc_edges(dm, true, true);
+		BKE_mesh_calc_normals(dm);
+		BKE_mesh_tessface_ensure(dm);
+		BKE_mesh_runtime_looptri_ensure(dm);
+		dm->runtime.cd_dirty_vert |= CD_MASK_NORMAL;
+	}
+}
+
+
+Mesh* BKE_repolygonize_dm(Mesh *dm, float thresh, float basesize[3], float wiresize, float rendersize,
+                                 bool render, bool override_size, int defgrp_size)
+{
+	Mesh *result = NULL;
+	DispList *dl;
+	unsigned int a;
+	PROCESS process = {0};
+	process.thresh = thresh;
+
+	if      (process.thresh < 0.001f) process.converge_res = 16;
+	else if (process.thresh < 0.01f)  process.converge_res = 8;
+	else if (process.thresh < 0.1f)   process.converge_res = 4;
+	else                              process.converge_res = 2;
+
+	//if ((!render) && (mb->flag == MB_UPDATE_NEVER)) return;
+	//if ((G.moving & (G_TRANSFORM_OBJ | G_TRANSFORM_EDIT)) && mb->flag == MB_UPDATE_FAST) return;
+
+	if (render) {
+		process.size = rendersize;
+	}
+	else {
+		process.size = wiresize;
+		/*if ((G.moving & (G_TRANSFORM_OBJ | G_TRANSFORM_EDIT)) && mb->flag == MB_UPDATE_HALFRES) {
+			process.size *= 2.0f;
+		}*/
+	}
+
+	process.delta = process.size * 0.001f;
+
+	process.pgn_elements = BLI_memarena_new(BLI_MEMARENA_STD_BUFSIZE, "Metaball memarena");
+
+	/* initialize from DM */
+	init_meta_dm(&process, dm, 2.0f, 2.0f, basesize, override_size, defgrp_size);
+
+	if (process.totelem > 0) {
+		build_bvh_spatial(&process, &process.metaball_bvh, 0, process.totelem, &process.allbb);
+
+		process.orig_index = MEM_callocN(process.totelem * sizeof(int), "process origindex");
+
+		/* don't polygonize metaballs with too high resolution (base mball to small)
+		 * note: Eps was 0.0001f but this was giving problems for blood animation for durian, using 0.00001f */
+		if (basesize[0] > 0.00001f * (process.allbb.max[0] - process.allbb.min[0]) ||
+		    basesize[1] > 0.00001f * (process.allbb.max[1] - process.allbb.min[1]) ||
+		    basesize[2] > 0.00001f * (process.allbb.max[2] - process.allbb.min[2]))
+		{
+			polygonize(&process);
+
+			/* add resulting surface to displist */
+			if (process.curindex) {
+				dl = MEM_callocN(sizeof(DispList), "mballdisp");
+				dl->type = DL_INDEX4;
+				dl->nr = (int)process.curvertex;
+				dl->parts = (int)process.curindex;
+
+				dl->index = (int *)process.indices;
+
+				for (a = 0; a < process.curvertex; a++) {
+					normalize_v3(process.no[a]);
+				}
+
+				dl->verts = (float *)process.co;
+				dl->nors = (float *)process.no;
+
+				result = BKE_mesh_new_nomain(dl->nr, 0, 0, dl->parts * 4, dl->parts);
+				BKE_dm_from_metaball(dl, result, dm, process.orig_index);
+				BKE_displist_elem_free(dl);
+			}
+		}
+	}
+
+	if (!result)
+		result =  BKE_mesh_new_nomain(0, 0, 0, 0, 0); //return an empty mesh
+
+	freepolygonize(&process);
+
+	return result;
 }

--- a/source/blender/blenkernel/intern/remesh_voxel.c
+++ b/source/blender/blenkernel/intern/remesh_voxel.c
@@ -1,0 +1,198 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) 2001-2002 by NaN Holding BV.
+ * All rights reserved.
+ */
+
+/** \file
+ * \ingroup bke
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <float.h>
+#include <ctype.h>
+
+#include "MEM_guardedalloc.h"
+
+#include "BLI_blenlib.h"
+#include "BLI_math.h"
+#include "BLI_utildefines.h"
+
+#include "DNA_object_types.h"
+#include "DNA_mesh_types.h"
+#include "DNA_meshdata_types.h"
+
+#include "BKE_mesh.h"
+#include "BKE_mesh_runtime.h"
+#include "BKE_library.h"
+#include "BKE_customdata.h"
+#include "BKE_bvhutils.h"
+#include "BKE_remesh.h"
+
+#ifdef WITH_OPENVDB
+#  include "openvdb_capi.h"
+#endif
+
+struct OpenVDBLevelSet *BKE_remesh_voxel_ovdb_mesh_to_level_set_create(
+    Mesh *mesh, struct OpenVDBTransform *transform)
+{
+  BKE_mesh_runtime_looptri_recalc(mesh);
+  const MLoopTri *looptri = BKE_mesh_runtime_looptri_ensure(mesh);
+  MVertTri *verttri = MEM_callocN(sizeof(*verttri) * BKE_mesh_runtime_looptri_len(mesh),
+                                  "remesh_looptri");
+  BKE_mesh_runtime_verttri_from_looptri(
+      verttri, mesh->mloop, looptri, BKE_mesh_runtime_looptri_len(mesh));
+
+  int totfaces = BKE_mesh_runtime_looptri_len(mesh);
+  unsigned int totverts = mesh->totvert;
+  float *verts = (float *)MEM_calloc_arrayN(totverts * 3, sizeof(float), "remesh_input_verts");
+  unsigned int *faces = (unsigned int *)MEM_calloc_arrayN(
+      totfaces * 3, sizeof(unsigned int), "remesh_intput_faces");
+
+  for (int i = 0; i < totverts; i++) {
+    MVert mvert = mesh->mvert[i];
+    verts[i * 3] = mvert.co[0];
+    verts[i * 3 + 1] = mvert.co[1];
+    verts[i * 3 + 2] = mvert.co[2];
+  }
+
+  for (int i = 0; i < totfaces; i++) {
+    MVertTri vt = verttri[i];
+    faces[i * 3] = vt.tri[0];
+    faces[i * 3 + 1] = vt.tri[1];
+    faces[i * 3 + 2] = vt.tri[2];
+  }
+
+  struct OpenVDBLevelSet *level_set = OpenVDBLevelSet_create(false, NULL);
+  OpenVDBLevelSet_mesh_to_level_set(level_set, verts, faces, totverts, totfaces, transform);
+
+  MEM_freeN(verts);
+  MEM_freeN(faces);
+  MEM_freeN(verttri);
+
+  return level_set;
+}
+
+Mesh *BKE_remesh_voxel_ovdb_volume_to_mesh_nomain(struct OpenVDBLevelSet *level_set,
+                                                  double isovalue,
+                                                  double adaptivity,
+                                                  bool relax_disoriented_triangles)
+{
+  struct OpenVDBVolumeToMeshData output_mesh;
+  OpenVDBLevelSet_volume_to_mesh(
+      level_set, &output_mesh, isovalue, adaptivity, relax_disoriented_triangles);
+
+  Mesh *mesh = BKE_mesh_new_nomain(
+      output_mesh.totvertices, 0, output_mesh.totquads + output_mesh.tottriangles, 0, 0);
+  int q = output_mesh.totquads;
+
+  for (int i = 0; i < output_mesh.totvertices; i++) {
+    float vco[3] = {output_mesh.vertices[i * 3],
+                    output_mesh.vertices[i * 3 + 1],
+                    output_mesh.vertices[i * 3 + 2]};
+    copy_v3_v3(mesh->mvert[i].co, vco);
+  }
+
+  for (int i = 0; i < output_mesh.totquads; i++) {
+    mesh->mface[i].v4 = output_mesh.quads[i * 4];
+    mesh->mface[i].v3 = output_mesh.quads[i * 4 + 1];
+    mesh->mface[i].v2 = output_mesh.quads[i * 4 + 2];
+    mesh->mface[i].v1 = output_mesh.quads[i * 4 + 3];
+  }
+
+  for (int i = 0; i < output_mesh.tottriangles; i++) {
+    mesh->mface[i + q].v4 = 0;
+    mesh->mface[i + q].v3 = output_mesh.triangles[i * 3];
+    mesh->mface[i + q].v2 = output_mesh.triangles[i * 3 + 1];
+    mesh->mface[i + q].v1 = output_mesh.triangles[i * 3 + 2];
+  }
+
+  BKE_mesh_calc_edges_tessface(mesh);
+  BKE_mesh_convert_mfaces_to_mpolys(mesh);
+  BKE_mesh_calc_normals(mesh);
+
+  MEM_freeN(output_mesh.quads);
+  MEM_freeN(output_mesh.vertices);
+
+  if (output_mesh.tottriangles > 0) {
+    MEM_freeN(output_mesh.triangles);
+  }
+
+  return mesh;
+}
+
+/*caller needs to free returned data */
+MLoopCol *BKE_remesh_remap_loop_vertex_color_layer(Mesh *mesh)
+{
+  MLoopCol *source_color = CustomData_get_layer(&mesh->ldata, CD_MLOOPCOL);
+  MLoopCol *remap = NULL;
+  if (source_color) {
+    int i = 0;
+    remap = MEM_calloc_arrayN(mesh->totvert, sizeof(MLoopCol), "oldcolor");
+    /*map loopbased storage onto vertices*/
+    for (i = 0; i < mesh->totloop; i++) {
+      MLoopCol c = source_color[i];
+      // printf("COLOR %d %d %d %d %d \n", mesh->mloop[i].v, c.r, c.g, c.b, c.a);
+      remap[mesh->mloop[i].v].r = c.r;
+      remap[mesh->mloop[i].v].g = c.g;
+      remap[mesh->mloop[i].v].b = c.b;
+      remap[mesh->mloop[i].v].a = c.a;
+    }
+  }
+
+  return remap;
+}
+
+void BKE_remesh_voxel_reproject_remapped_vertex_paint(Mesh *target, Mesh *source, MLoopCol *remap)
+{
+  BVHTreeFromMesh bvhtree = {NULL};
+
+  if (remap) {
+    MVert *target_verts = target->mvert;
+    MLoop *target_loops = target->mloop;
+    MLoopCol *target_color = CustomData_add_layer(
+        &target->ldata, CD_MLOOPCOL, CD_CALLOC, NULL, target->totloop);
+    BKE_bvhtree_from_mesh_get(&bvhtree, source, BVHTREE_FROM_VERTS, 2);
+
+    for (int i = 0; i < target->totloop; i++) {
+      float from_co[3];
+      BVHTreeNearest nearest;
+      nearest.index = -1;
+      nearest.dist_sq = FLT_MAX;
+      copy_v3_v3(from_co, target_verts[target_loops[i].v].co);
+      BLI_bvhtree_find_nearest(
+          bvhtree.tree, from_co, &nearest, bvhtree.nearest_callback, &bvhtree);
+
+      if (nearest.index != -1) {
+        MLoopCol c = remap[nearest.index];
+        // printf("MAPPED %d %d %d %d %d %d \n", i, nearest.index, c.r, c.g, c.b, c.a);
+        target_color[i].r = c.r;
+        target_color[i].g = c.g;
+        target_color[i].b = c.b;
+        target_color[i].a = c.a;
+      }
+      else {
+        target_color[i].r = 255;
+        target_color[i].g = 255;
+        target_color[i].b = 255;
+        target_color[i].a = 255;
+      }
+    }
+  }
+}

--- a/source/blender/blenloader/intern/readfile.c
+++ b/source/blender/blenloader/intern/readfile.c
@@ -5803,6 +5803,11 @@ static void direct_link_modifiers(FileData *fd, ListBase *lb)
       pmmd->level_set = NULL;
       pmmd->mesher_mask = NULL;
     }
+    else if (md->type == eModifierType_Remesh) {
+      RemeshModifierData *rmd = (RemeshModifierData *)md;
+      link_list(fd, &rmd->csg_operands);
+      rmd->mesh_cached = newdataadr(fd, rmd->mesh_cached);
+    }
   }
 }
 

--- a/source/blender/blenloader/intern/writefile.c
+++ b/source/blender/blenloader/intern/writefile.c
@@ -1763,6 +1763,12 @@ static void write_modifiers(WriteData *wd, ListBase *modbase)
       LevelSetFilter *filter;
       for (filter = pmmd->filters.first; filter; filter = filter->next) {
         writestruct(wd, DATA, LevelSetFilter, 1, filter);
+    }
+    else if (md->type == eModifierType_Remesh) {
+      RemeshModifierData *rmd = (RemeshModifierData *)md;
+      CSGVolume_Object *vcob;
+      for (vcob = rmd->csg_operands.first; vcob; vcob = vcob->next) {
+        writestruct(wd, DATA, CSGVolume_Object, 1, vcob);
       }
     }
   }

--- a/source/blender/blenloader/intern/writefile.c
+++ b/source/blender/blenloader/intern/writefile.c
@@ -1763,6 +1763,7 @@ static void write_modifiers(WriteData *wd, ListBase *modbase)
       LevelSetFilter *filter;
       for (filter = pmmd->filters.first; filter; filter = filter->next) {
         writestruct(wd, DATA, LevelSetFilter, 1, filter);
+      }
     }
     else if (md->type == eModifierType_Remesh) {
       RemeshModifierData *rmd = (RemeshModifierData *)md;

--- a/source/blender/editors/object/CMakeLists.txt
+++ b/source/blender/editors/object/CMakeLists.txt
@@ -85,10 +85,16 @@ if(WITH_INTERNATIONAL)
 endif()
 
 if(WITH_OPENVDB)
-    add_definitions(-DWITH_OPENVDB)
-    list(APPEND INC
-        ../../../../intern/openvdb
+  add_definitions(-DWITH_OPENVDB)
+  list(APPEND INC
+     ../../../../intern/openvdb
+  )
+
+  if(WITH_OPENVDB_BLOSC)
+    add_definitions(
+      -DWITH_OPENVDB_BLOSC
     )
+  endif()
 endif()
 
 blender_add_lib(bf_editor_object "${SRC}" "${INC}" "${INC_SYS}" "${LIB}")

--- a/source/blender/editors/object/object_edit.c
+++ b/source/blender/editors/object/object_edit.c
@@ -32,6 +32,7 @@
 #include "MEM_guardedalloc.h"
 
 #include "BLI_blenlib.h"
+#include "BLI_math.h"
 #include "BLI_utildefines.h"
 #include "BLI_ghash.h"
 
@@ -79,6 +80,11 @@
 #include "BKE_report.h"
 #include "BKE_scene.h"
 #include "BKE_workspace.h"
+#include "BKE_mesh_runtime.h"
+#include "BKE_library.h"
+#include "BKE_customdata.h"
+#include "BKE_bvhutils.h"
+#include "BKE_remesh.h"
 
 #include "DEG_depsgraph.h"
 #include "DEG_depsgraph_build.h"
@@ -111,6 +117,10 @@
 #include "WM_toolsystem.h"
 
 #include "object_intern.h"  // own include
+
+#ifdef WITH_OPENVDB
+#  include "openvdb_capi.h"
+#endif
 
 /* prototypes */
 typedef struct MoveToCollectionData MoveToCollectionData;

--- a/source/blender/editors/object/object_intern.h
+++ b/source/blender/editors/object/object_intern.h
@@ -285,4 +285,13 @@ void TRANSFORM_OT_vertex_random(struct wmOperatorType *ot);
 void OBJECT_OT_data_transfer(struct wmOperatorType *ot);
 void OBJECT_OT_datalayout_transfer(struct wmOperatorType *ot);
 
+void OBJECT_OT_remesh(struct wmOperatorType *ot);
+void OBJECT_OT_vertex_to_loop_colors(struct wmOperatorType *ot);
+void OBJECT_OT_loop_to_vertex_colors(struct wmOperatorType *ot);
+
+void REMESH_OT_csg_add(struct wmOperatorType *ot);
+void REMESH_OT_csg_remove(struct wmOperatorType *ot);
+void REMESH_OT_csg_move_up(struct wmOperatorType *ot);
+void REMESH_OT_csg_move_down(struct wmOperatorType *ot);
+
 #endif /* __OBJECT_INTERN_H__ */

--- a/source/blender/editors/object/object_modifier.c
+++ b/source/blender/editors/object/object_modifier.c
@@ -2732,3 +2732,246 @@ void OBJECT_OT_levelset_filter_move(wmOperatorType *ot)
 	ot->prop = RNA_def_enum(ot->srna, "direction", filter_move, LVLSET_FILTER_MOVE_UP, "Direction", "");
 	edit_modifier_properties(ot);
 }
+
+static bool remesh_update_check(bContext *C, wmOperator *op)
+{
+  Object *ob = ED_object_active_context(C);
+  RemeshModifierData *rmd = (RemeshModifierData *)edit_modifier_property_get(
+      op, ob, eModifierType_Remesh);
+  bool do_update = true;
+
+  if (rmd->mode == MOD_REMESH_VOXEL) {
+    if (((rmd->flag & MOD_REMESH_LIVE_REMESH) == 0) && rmd->mesh_cached) {
+      do_update = false;
+    }
+  }
+
+  return do_update;
+}
+
+static bool remesh_csg_poll(bContext *C)
+{
+  return edit_modifier_poll_generic(C, &RNA_RemeshModifier, 0);
+}
+
+static int remesh_csg_add_exec(bContext *C, wmOperator *op)
+{
+  Object *ob = ED_object_active_context(C);
+  Main *bmain = CTX_data_main(C);
+  RemeshModifierData *rmd = (RemeshModifierData *)edit_modifier_property_get(
+      op, ob, eModifierType_Remesh);
+
+  if (rmd == NULL) {
+    return OPERATOR_CANCELLED;
+  }
+
+  CSGVolume_Object *vcob = MEM_callocN(sizeof(CSGVolume_Object), "vcob");
+  vcob->voxel_size = rmd->voxel_size;
+  vcob->flag |= MOD_REMESH_CSG_OBJECT_ENABLED;
+  vcob->flag |= MOD_REMESH_CSG_SYNC_VOXEL_SIZE;
+  vcob->sampler = eRemeshModifierSampler_None;
+  vcob->voxel_percentage = 100.0f;
+
+  BLI_addtail(&rmd->csg_operands, vcob);
+
+  if (remesh_update_check(C, op)) {
+    if (BLI_listbase_is_single(&rmd->csg_operands)) {
+      /*trigger update to detach modifier transform relation from modifier */
+      DEG_relations_tag_update(bmain);
+    }
+
+    DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY | ID_RECALC_COPY_ON_WRITE);
+    WM_event_add_notifier(C, NC_OBJECT | ND_MODIFIER, ob);
+  }
+
+  return OPERATOR_FINISHED;
+}
+
+static int remesh_csg_add_invoke(bContext *C, wmOperator *op, const wmEvent *UNUSED(event))
+{
+  if (edit_modifier_invoke_properties(C, op))
+    return remesh_csg_add_exec(C, op);
+  else
+    return OPERATOR_CANCELLED;
+}
+
+void REMESH_OT_csg_add(wmOperatorType *ot)
+{
+  /* identifiers */
+  ot->name = "Add CSG Object";
+  ot->description = "Add CSG Object to remesh modifier";
+  ot->idname = "REMESH_OT_csg_add";
+
+  /* api callbacks */
+  ot->poll = remesh_csg_poll;
+  ot->invoke = remesh_csg_add_invoke;
+  ot->exec = remesh_csg_add_exec;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO | OPTYPE_INTERNAL;
+  edit_modifier_properties(ot);
+}
+
+static int remesh_csg_remove_exec(bContext *C, wmOperator *op)
+{
+  Object *ob = ED_object_active_context(C);
+  Main *bmain = CTX_data_main(C);
+  RemeshModifierData *rmd = (RemeshModifierData *)edit_modifier_property_get(
+      op, ob, eModifierType_Remesh);
+  int index = RNA_int_get(op->ptr, "index");
+
+  if (rmd == NULL) {
+    return OPERATOR_CANCELLED;
+  }
+
+  CSGVolume_Object *vcob = (CSGVolume_Object *)BLI_findlink(&rmd->csg_operands, index);
+  if (vcob) {
+    BLI_remlink(&rmd->csg_operands, vcob);
+  }
+
+  if (remesh_update_check(C, op)) {
+    if (BLI_listbase_is_empty(&rmd->csg_operands)) {
+      /*trigger update to detach modifier transform relation from modifier */
+      DEG_relations_tag_update(bmain);
+    }
+
+    DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY | ID_RECALC_COPY_ON_WRITE);
+    WM_event_add_notifier(C, NC_OBJECT | ND_MODIFIER, ob);
+  }
+
+  return OPERATOR_FINISHED;
+}
+
+static int remesh_csg_remove_invoke(bContext *C, wmOperator *op, const wmEvent *UNUSED(event))
+{
+  if (edit_modifier_invoke_properties(C, op))
+    return remesh_csg_remove_exec(C, op);
+  else
+    return OPERATOR_CANCELLED;
+}
+
+void REMESH_OT_csg_remove(wmOperatorType *ot)
+{
+  /* identifiers */
+  ot->name = "Remove CSG Object";
+  ot->description = "Remove CSG Object at index";
+  ot->idname = "REMESH_OT_csg_remove";
+
+  /* api callbacks */
+  ot->poll = remesh_csg_poll;
+  ot->invoke = remesh_csg_remove_invoke;
+  ot->exec = remesh_csg_remove_exec;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO | OPTYPE_INTERNAL;
+  edit_modifier_properties(ot);
+
+  RNA_def_int(
+      ot->srna, "index", 0, 0, INT_MAX, "Index", "Index of the Object to remove", 0, INT_MAX);
+}
+
+static int remesh_csg_move_up_exec(bContext *C, wmOperator *op)
+{
+  Object *ob = ED_object_active_context(C);
+  RemeshModifierData *rmd = (RemeshModifierData *)edit_modifier_property_get(
+      op, ob, eModifierType_Remesh);
+  int index = RNA_int_get(op->ptr, "index");
+
+  if (rmd == NULL) {
+    return OPERATOR_CANCELLED;
+  }
+
+  CSGVolume_Object *vcob = (CSGVolume_Object *)BLI_findlink(&rmd->csg_operands, index);
+  if (vcob) {
+    BLI_remlink(&rmd->csg_operands, vcob);
+    BLI_insertlinkbefore(&rmd->csg_operands, vcob->prev, vcob);
+  }
+
+  if (remesh_update_check(C, op)) {
+    DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY | ID_RECALC_COPY_ON_WRITE);
+    WM_event_add_notifier(C, NC_OBJECT | ND_MODIFIER, ob);
+  }
+
+  return OPERATOR_FINISHED;
+}
+
+static int remesh_csg_move_up_invoke(bContext *C, wmOperator *op, const wmEvent *UNUSED(event))
+{
+  if (edit_modifier_invoke_properties(C, op))
+    return remesh_csg_move_up_exec(C, op);
+  else
+    return OPERATOR_CANCELLED;
+}
+
+void REMESH_OT_csg_move_up(wmOperatorType *ot)
+{
+  /* identifiers */
+  ot->name = "Move CSG Object up";
+  ot->description = "Move CSG Object at index to previous index";
+  ot->idname = "REMESH_OT_csg_move_up";
+
+  /* api callbacks */
+  ot->poll = remesh_csg_poll;
+  ot->invoke = remesh_csg_move_up_invoke;
+  ot->exec = remesh_csg_move_up_exec;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO | OPTYPE_INTERNAL;
+  edit_modifier_properties(ot);
+
+  RNA_def_int(
+      ot->srna, "index", 0, 0, INT_MAX, "Index", "Index of the Object to move up", 0, INT_MAX);
+}
+
+static int remesh_csg_move_down_exec(bContext *C, wmOperator *op)
+{
+  Object *ob = ED_object_active_context(C);
+  RemeshModifierData *rmd = (RemeshModifierData *)edit_modifier_property_get(
+      op, ob, eModifierType_Remesh);
+  int index = RNA_int_get(op->ptr, "index");
+
+  if (rmd == NULL) {
+    return OPERATOR_CANCELLED;
+  }
+
+  CSGVolume_Object *vcob = (CSGVolume_Object *)BLI_findlink(&rmd->csg_operands, index);
+  if (vcob) {
+    BLI_remlink(&rmd->csg_operands, vcob);
+    BLI_insertlinkafter(&rmd->csg_operands, vcob->next, vcob);
+  }
+
+  if (remesh_update_check(C, op)) {
+    DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY | ID_RECALC_COPY_ON_WRITE);
+    WM_event_add_notifier(C, NC_OBJECT | ND_MODIFIER, ob);
+  }
+
+  return OPERATOR_FINISHED;
+}
+
+static int remesh_csg_move_down_invoke(bContext *C, wmOperator *op, const wmEvent *UNUSED(event))
+{
+  if (edit_modifier_invoke_properties(C, op))
+    return remesh_csg_move_down_exec(C, op);
+  else
+    return OPERATOR_CANCELLED;
+}
+
+void REMESH_OT_csg_move_down(wmOperatorType *ot)
+{
+  /* identifiers */
+  ot->name = "Move CSG Object down";
+  ot->description = "Move CSG Object at index to next index";
+  ot->idname = "REMESH_OT_csg_move_down";
+
+  /* api callbacks */
+  ot->poll = remesh_csg_poll;
+  ot->invoke = remesh_csg_move_down_invoke;
+  ot->exec = remesh_csg_move_down_exec;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO | OPTYPE_INTERNAL;
+  edit_modifier_properties(ot);
+
+  RNA_def_int(
+      ot->srna, "index", 0, 0, INT_MAX, "Index", "Index of the Object to move down", 0, INT_MAX);
+}

--- a/source/blender/editors/object/object_ops.c
+++ b/source/blender/editors/object/object_ops.c
@@ -261,6 +261,10 @@ void ED_operatortypes_object(void)
   WM_operatortype_append(OBJECT_OT_levelset_filter_add);
   WM_operatortype_append(OBJECT_OT_levelset_filter_remove);
   WM_operatortype_append(OBJECT_OT_levelset_filter_move);
+  WM_operatortype_append(REMESH_OT_csg_add);
+  WM_operatortype_append(REMESH_OT_csg_remove);
+  WM_operatortype_append(REMESH_OT_csg_move_down);
+  WM_operatortype_append(REMESH_OT_csg_move_up);
 }
 
 void ED_operatormacros_object(void)

--- a/source/blender/editors/sculpt_paint/sculpt_undo.c
+++ b/source/blender/editors/sculpt_paint/sculpt_undo.c
@@ -459,6 +459,7 @@ static void sculpt_undo_restore_list(bContext *C, ListBase *lb)
 {
   Scene *scene = CTX_data_scene(C);
   ViewLayer *view_layer = CTX_data_view_layer(C);
+  View3D *v3d = CTX_wm_view3d(C);
   Object *ob = OBACT(view_layer);
   Depsgraph *depsgraph = CTX_data_depsgraph(C);
   SculptSession *ss = ob->sculpt;
@@ -560,7 +561,7 @@ static void sculpt_undo_restore_list(bContext *C, ListBase *lb)
       }
     }
 
-    tag_update |= ((Mesh *)ob->data)->id.us > 1;
+    tag_update |= ((Mesh *)ob->data)->id.us > 1 || !BKE_sculptsession_use_pbvh_draw(ob, v3d);
 
     if (ss->kb || ss->modifiers_active) {
       Mesh *mesh = ob->data;

--- a/source/blender/editors/space_sequencer/sequencer_draw.c
+++ b/source/blender/editors/space_sequencer/sequencer_draw.c
@@ -38,12 +38,14 @@
 #include "DNA_space_types.h"
 #include "DNA_userdef_types.h"
 #include "DNA_sound_types.h"
+#include "DNA_anim_types.h"
 
 #include "BKE_context.h"
 #include "BKE_global.h"
 #include "BKE_sequencer.h"
 #include "BKE_sound.h"
 #include "BKE_scene.h"
+#include "BKE_fcurve.h"
 
 #include "IMB_colormanagement.h"
 #include "IMB_imbuf.h"
@@ -251,8 +253,10 @@ static void drawseqwave(View2D *v2d,
     float yscale = (y2 - y1) / 2.0f;
     float samplestep;
     float startsample, endsample;
+    float volume = seq->volume;
     float value1, value2;
     bSound *sound = seq->sound;
+    FCurve *fcu = id_data_find_fcurve(&scene->id, seq, &RNA_Sequence, "volume", 0, NULL);
 
     SoundWaveform *waveform;
 
@@ -329,8 +333,12 @@ static void drawseqwave(View2D *v2d,
         value2 = (1.0f - f) * value2 + f * waveform->data[p * 3 + 4];
       }
 
-      value1 *= seq->volume;
-      value2 *= seq->volume;
+      if (fcu) {
+        float evaltime = x1_offset + (i * stepsize);
+        volume = evaluate_fcurve(fcu, evaltime);
+      }
+      value1 *= volume;
+      value2 *= volume;
 
       if (value2 > 1 || value1 < -1) {
         immAttr4f(col, 1.0f, 0.0f, 0.0f, 0.5f);

--- a/source/blender/makesdna/DNA_modifier_types.h
+++ b/source/blender/makesdna/DNA_modifier_types.h
@@ -1498,6 +1498,10 @@ enum {
 typedef enum eRemeshModifierFlags {
   MOD_REMESH_FLOOD_FILL = (1 << 0),
   MOD_REMESH_SMOOTH_SHADING = (1 << 1),
+  MOD_REMESH_SMOOTH_NORMALS = (1 << 2),
+  MOD_REMESH_RELAX_TRIANGLES = (1 << 3),
+  MOD_REMESH_REPROJECT_VPAINT = (1 << 4),
+  MOD_REMESH_LIVE_REMESH = (1 << 5)
 } RemeshModifierFlags;
 
 typedef enum eRemeshModifierMode {
@@ -1507,7 +1511,77 @@ typedef enum eRemeshModifierMode {
   MOD_REMESH_MASS_POINT = 1,
   /* keeps sharp edges */
   MOD_REMESH_SHARP_FEATURES = 2,
+  /* OpenVDB voxel remesh */
+  MOD_REMESH_VOXEL = 3,
+  /* metaball remesh, turns vertices or particles into metaballs */
+  MOD_REMESH_METABALL = 4,
 } eRemeshModifierMode;
+
+typedef enum MetaballRemeshFlags {
+	MOD_REMESH_VERTICES = (1 << 0),
+	MOD_REMESH_PARTICLES = (1 << 1),
+} MetaballRemeshFlags;
+
+typedef enum {
+	eRemeshFlag_Alive    = (1 << 0),
+	eRemeshFlag_Dead     = (1 << 1),
+	eRemeshFlag_Unborn   = (1 << 2),
+	eRemeshFlag_Size     = (1 << 3),
+	eRemeshFlag_Verts    = (1 << 4),
+} MetaballRemeshPsysFlag;
+
+typedef enum {
+  eRemeshModifierOp_Union = 0,
+  eRemeshModifierOp_Difference = 1,
+  eRemeshModifierOp_Intersect = 2,
+} RemeshModifierOp;
+
+typedef enum {
+  eRemeshModifierSampler_None = 0,
+  eRemeshModifierSampler_Point = 1,
+  eRemeshModifierSampler_Box = 2,
+  eRemeshModifierSampler_Quadratic = 3,
+} RemeshModifierSampler;
+
+typedef enum eVoxelFilterType {
+  VOXEL_FILTER_NONE = 0,
+  VOXEL_FILTER_GAUSSIAN = 1,
+  VOXEL_FILTER_MEAN = 2,
+  VOXEL_FILTER_MEDIAN = 3,
+  VOXEL_FILTER_MEAN_CURVATURE = 4,
+  VOXEL_FILTER_LAPLACIAN = 5,
+  VOXEL_FILTER_DILATE = 6,
+  VOXEL_FILTER_ERODE = 7,
+} eVoxelFilterType;
+
+/*filter bias, aligned to openvdb */
+typedef enum eVoxelFilterBias {
+  VOXEL_BIAS_FIRST = 0,
+  VOXEL_BIAS_SECOND,
+  VOXEL_BIAS_THIRD,
+  VOXEL_BIAS_WENO5,
+  VOXEL_BIAS_HJWENO5,
+} eVoxelFilterBias;
+
+typedef enum eCSGVolumeOperandFlags {
+  MOD_REMESH_CSG_OBJECT_ENABLED = (1 << 0),
+  MOD_REMESH_CSG_SYNC_VOXEL_SIZE = (1 << 1),
+  MOD_REMESH_CSG_VOXEL_PERCENTAGE = (1 << 2),
+} eCSGVolumeOperandFlags;
+
+typedef struct CSGVolume_Object {
+  struct CSGVolume_Object *next, *prev;
+  struct RemeshModifierData *md;
+  // modifier we belong to (currently unused, probably should be deprecated/removed ?)
+  struct Object *object;
+  float voxel_size;
+  float voxel_percentage;
+  char operation;
+  char flag;
+  char sampler;
+  char _pad[5];
+
+} CSGVolume_Object;
 
 typedef struct RemeshModifierData {
   ModifierData modifier;
@@ -1519,6 +1593,29 @@ typedef struct RemeshModifierData {
   float scale;
 
   float hermite_num;
+
+  /* for voxelremesher */
+  float voxel_size;
+  float isovalue;
+  float adaptivity;
+  int filter_type;
+  int filter_bias;
+  int filter_width;
+  int filter_iterations;
+
+  /* volume csg */
+  struct ListBase csg_operands;
+  struct Mesh *mesh_cached;
+
+  /*for metaball remesher*/
+  float rendersize;
+  float wiresize;
+  float thresh;
+  float basesize[3];
+  int input;
+  int pflag;
+  int psys;
+  char size_defgrp_name[64];  /* MAX_VGROUP_NAME */
 
   /* octree depth */
   char depth;

--- a/source/blender/makesrna/RNA_access.h
+++ b/source/blender/makesrna/RNA_access.h
@@ -510,6 +510,7 @@ extern StructRNA RNA_RadarSensor;
 extern StructRNA RNA_RandomSensor;
 extern StructRNA RNA_RaySensor;
 extern StructRNA RNA_Region;
+extern StructRNA RNA_RemeshModifier;
 extern StructRNA RNA_RenderEngine;
 extern StructRNA RNA_RenderEngineSettings;
 extern StructRNA RNA_RenderEngineSettingsClay;

--- a/source/blender/makesrna/intern/rna_modifier.c
+++ b/source/blender/makesrna/intern/rna_modifier.c
@@ -451,6 +451,8 @@ const EnumPropertyItem rna_enum_axis_flag_xyz_items[] = {
 #  include "DNA_curve_types.h"
 #  include "DNA_smoke_types.h"
 
+#  include "BLI_listbase.h"
+
 #  include "BKE_cachefile.h"
 #  include "BKE_context.h"
 #  include "BKE_mesh_runtime.h"
@@ -467,6 +469,12 @@ const EnumPropertyItem rna_enum_axis_flag_xyz_items[] = {
 #  ifdef WITH_ALEMBIC
 #    include "ABC_alembic.h"
 #  endif
+
+static bool rna_CSG_object_poll(PointerRNA *UNUSED(ptr), PointerRNA value)
+{
+  int type = ((Object *)value.id.data)->type;
+  return type == OB_MESH;  // || type == OB_CURVE;
+}
 
 static void rna_UVProject_projectors_begin(CollectionPropertyIterator *iter, PointerRNA *ptr)
 {
@@ -628,16 +636,37 @@ static char *rna_Modifier_path(PointerRNA *ptr)
   return BLI_sprintfN("modifiers[\"%s\"]", name_esc);
 }
 
+static bool rna_Modifier_update_check(PointerRNA *ptr)
+{
+  ModifierData *md = ptr->data;
+  bool do_update = true;
+
+  if (md->type == eModifierType_Remesh) {
+    RemeshModifierData *rmd = (RemeshModifierData *)md;
+    if (rmd->mode == MOD_REMESH_VOXEL) {
+      if (((rmd->flag & MOD_REMESH_LIVE_REMESH) == 0) && rmd->mesh_cached) {
+        do_update = false;
+      }
+    }
+  }
+
+  return do_update;
+}
+
 static void rna_Modifier_update(Main *UNUSED(bmain), Scene *UNUSED(scene), PointerRNA *ptr)
 {
-  DEG_id_tag_update(ptr->id.data, ID_RECALC_GEOMETRY);
-  WM_main_add_notifier(NC_OBJECT | ND_MODIFIER, ptr->id.data);
+  if (rna_Modifier_update_check(ptr)) {
+    DEG_id_tag_update(ptr->id.data, ID_RECALC_GEOMETRY);
+    WM_main_add_notifier(NC_OBJECT | ND_MODIFIER, ptr->id.data);
+  }
 }
 
 static void rna_Modifier_dependency_update(Main *bmain, Scene *scene, PointerRNA *ptr)
 {
-  rna_Modifier_update(bmain, scene, ptr);
-  DEG_relations_tag_update(bmain);
+  if (rna_Modifier_update_check(ptr)) {
+    rna_Modifier_update(bmain, scene, ptr);
+    DEG_relations_tag_update(bmain);
+  }
 }
 
 /* Vertex Groups */
@@ -664,6 +693,7 @@ RNA_MOD_VGROUP_NAME_SET(Lattice, name);
 RNA_MOD_VGROUP_NAME_SET(Mask, vgroup);
 RNA_MOD_VGROUP_NAME_SET(MeshDeform, defgrp_name);
 RNA_MOD_VGROUP_NAME_SET(NormalEdit, defgrp_name);
+RNA_MOD_VGROUP_NAME_SET(Remesh, size_defgrp_name);
 RNA_MOD_VGROUP_NAME_SET(Shrinkwrap, vgroup_name);
 RNA_MOD_VGROUP_NAME_SET(SimpleDeform, vgroup_name);
 RNA_MOD_VGROUP_NAME_SET(Smooth, defgrp_name);
@@ -850,6 +880,38 @@ static void rna_UVProjector_object_set(PointerRNA *ptr,
   Object *ob = (Object *)value.data;
   id_lib_extern((ID *)ob);
   *ob_p = ob;
+}
+
+static PointerRNA rna_CSGVolume_object_get(PointerRNA *ptr)
+{
+  CSGVolume_Object *vcob = (CSGVolume_Object *)ptr->data;
+  return rna_pointer_inherit_refine(ptr, &RNA_Object, vcob->object);
+}
+
+static void rna_CSGVolume_object_set(PointerRNA *ptr, PointerRNA value, ReportList *reports)
+{
+  CSGVolume_Object *vcob = (CSGVolume_Object *)ptr->data;
+  Object *ob = (Object *)value.data;
+  id_lib_extern((ID *)ob);
+  vcob->object = ob;
+  if (ob) {
+    ob->dt = OB_WIRE;
+    DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
+    WM_main_add_notifier(NC_OBJECT | ND_DRAW, ob);
+  }
+}
+
+static void rna_RemeshModifier_voxel_size_set(PointerRNA *ptr, float value)
+{
+  RemeshModifierData *rmd = (RemeshModifierData *)ptr->data;
+  CSGVolume_Object *vcob;
+
+  rmd->voxel_size = value;
+  for (vcob = rmd->csg_operands.first; vcob; vcob = vcob->next) {
+    if (vcob->flag & MOD_REMESH_CSG_SYNC_VOXEL_SIZE) {
+      vcob->voxel_size = value;
+    }
+  }
 }
 
 #  undef RNA_MOD_OBJECT_SET
@@ -4747,7 +4809,124 @@ static void rna_def_modifier_remesh(BlenderRNA *brna)
        0,
        "Sharp",
        "Output a surface that reproduces sharp edges and corners from the input mesh"},
+      {MOD_REMESH_VOXEL,
+       "VOXEL",
+       0,
+       "Voxel",
+       "Invokes the OpenVDB voxel remesher and generates quad only meshes"},
+      {MOD_REMESH_METABALL, 
+        "METABALL", 
+        0, 
+        "Metaball",
+	    "Output a surface that consists of metaballs based from the vertices or particles of the input mesh"},
       {0, NULL, 0, NULL, NULL},
+  };
+
+  static const EnumPropertyItem filter_type_items[] = {
+      {VOXEL_FILTER_NONE, "NONE", 0, "None", "No Filter"},
+      {VOXEL_FILTER_GAUSSIAN, "GAUSSIAN", 0, "Gaussian", "Gaussian Filter"},
+      {VOXEL_FILTER_MEAN, "MEAN", 0, "Mean", "Mean Filter"},
+      {VOXEL_FILTER_MEDIAN, "MEDIAN", 0, "Median", "Median Filter"},
+      {VOXEL_FILTER_MEAN_CURVATURE,
+       "MEAN_CURVATURE",
+       0,
+       "Mean Curvature",
+       "Mean Curvature Filter"},
+      {VOXEL_FILTER_LAPLACIAN, "LAPLACIAN", 0, "Laplacian", "Laplacian Filter"},
+      {VOXEL_FILTER_DILATE, "DILATE", 0, "Dilate", "Dilate Filter"},
+      {VOXEL_FILTER_ERODE, "ERODE", 0, "Erode", "Erode Filter"},
+      {0, NULL, 0, NULL, NULL},
+  };
+
+  static const EnumPropertyItem filter_bias_items[] = {
+      {VOXEL_BIAS_FIRST, "FIRST", 0, "First", "First bias"},
+      {VOXEL_BIAS_SECOND, "SECOND", 0, "Second", "Second bias"},
+      {VOXEL_BIAS_THIRD, "THIRD", 0, "Third", "Third bias"},
+      {VOXEL_BIAS_WENO5, "WENO5", 0, "Weno5", "Weno5 bias"},
+      {VOXEL_BIAS_HJWENO5, "HJWENO5", 0, "HjWeno5", "HjWeno5 bias"},
+      {0, NULL, 0, NULL, NULL},
+  };
+
+  static const EnumPropertyItem prop_operation_items[] = {
+      {eRemeshModifierOp_Union, "UNION", 0, "Union", "Combine two meshes in an additive way"},
+      {eRemeshModifierOp_Difference,
+       "DIFFERENCE",
+       0,
+       "Difference",
+       "Combine two meshes in a subtractive way"},
+      {eRemeshModifierOp_Intersect,
+       "INTERSECT",
+       0,
+       "Intersect",
+       "Keep the part of the mesh that intersects with the other selected object"},
+      {0, NULL, 0, NULL, NULL},
+  };
+
+  static const EnumPropertyItem prop_sampler_items[] = {
+      {eRemeshModifierSampler_None,
+       "None",
+       0,
+       "None",
+       "Do not resample to match grid transforms."},
+      {eRemeshModifierSampler_Point,
+       "POINT",
+       0,
+       "Point",
+       "Use OpenVDBs point sampler to match grid transforms."},
+      {eRemeshModifierSampler_Box,
+       "BOX",
+       0,
+       "Box",
+       "Use OpenVDBs box sampler to match grid transforms."},
+      {eRemeshModifierSampler_Quadratic,
+       "QUADRATIC",
+       0,
+       "Quadratic",
+       "Use OpenVDBs quadratic sampler to match grid transforms."},
+      {0, NULL, 0, NULL, NULL},
+  };
+
+  static const EnumPropertyItem mesh_items[] =  {
+      {MOD_REMESH_VERTICES, 
+       "VERTICES", 
+       0, 
+       "Vertices", 
+       "Output a metaball surface using vertex input data"},
+      {MOD_REMESH_PARTICLES, 
+       "PARTICLES", 
+       0, 
+       "Particles", 
+       "Output a metaball surface using particle input data"},
+	  {0, NULL, 0, NULL, NULL}
+  };
+	
+  static const EnumPropertyItem filter_items[] =  {
+	  {eRemeshFlag_Alive, 
+       "ALIVE", 
+       0, 
+       "Alive", 
+       "Output a metaball surface using alive particle input data"},
+	  {eRemeshFlag_Dead, 
+       "DEAD", 
+        0, 
+       "Dead", 
+       "Output a metaball surface using dead particle input data"},
+      {eRemeshFlag_Unborn, 
+       "UNBORN", 
+       0, 
+       "Unborn", 
+       "Output a metaball surface using unborn particle input data"},
+      {eRemeshFlag_Size, 
+       "SIZE", 
+       0, 
+       "Size", 
+       "Override metaball size by individual particle size"},
+      {eRemeshFlag_Verts, 
+       "VERTS", 
+       0, 
+       "Verts", 
+       "Only output a vertex per particle"},
+	  {0, NULL, 0, NULL, NULL}
   };
 
   StructRNA *srna;
@@ -4809,6 +4988,192 @@ static void rna_def_modifier_remesh(BlenderRNA *brna)
   RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_SMOOTH_SHADING);
   RNA_def_property_ui_text(
       prop, "Smooth Shading", "Output faces with smooth shading rather than flat shaded");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  /*metaball remesher*/
+
+  prop = RNA_def_property(srna, "mball_resolution", PROP_FLOAT, PROP_DISTANCE);
+  RNA_def_property_float_sdna(prop, NULL, "wiresize");
+  RNA_def_property_range(prop, 0.0001f, 10000.0f);
+  RNA_def_property_ui_range(prop, 0.05f, 1000.0f, 2.5f, 3);
+  RNA_def_property_ui_text(prop, "Wire Size", "Polygonization resolution in the 3D viewport");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+	
+  prop = RNA_def_property(srna, "mball_render_resolution", PROP_FLOAT, PROP_DISTANCE);
+  RNA_def_property_float_sdna(prop, NULL, "rendersize");
+  RNA_def_property_range(prop, 0.0001f, 10000.0f);
+  RNA_def_property_ui_range(prop, 0.025f, 1000.0f, 2.5f, 3);
+  RNA_def_property_ui_text(prop, "Render Size", "Polygonization resolution in rendering");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "mball_threshold", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_float_sdna(prop, NULL, "thresh");
+  RNA_def_property_range(prop, 0.0f, 100.0f);
+  RNA_def_property_ui_text(prop, "Threshold", "Influence of meta elements");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "mball_size", PROP_FLOAT, PROP_XYZ);
+  RNA_def_property_float_sdna(prop, NULL, "basesize");
+  RNA_def_property_ui_range(prop, 0.0001f, 10.0f, 0.1f, 3);
+  RNA_def_property_range(prop, 0.001f, 100.0f);
+  RNA_def_property_array(prop, 3);
+  RNA_def_property_ui_text(prop, "Size",
+                             "The base size of each metaball element");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "input", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_items(prop, mesh_items);
+  RNA_def_property_flag(prop, PROP_ENUM_FLAG);
+  RNA_def_property_ui_text(prop, "Input", "Which input source to consider in remeshing");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "psys", PROP_INT, PROP_NONE);
+  RNA_def_property_int_sdna(prop, NULL, "psys");
+  RNA_def_property_range(prop, 1, INT_MAX);
+  RNA_def_property_ui_text(prop, "Particle System Index", "Index of the input particle system to use");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "filter", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_sdna(prop, NULL, "pflag");
+  RNA_def_property_enum_items(prop, filter_items);
+  RNA_def_property_flag(prop, PROP_ENUM_FLAG);
+  RNA_def_property_ui_text(prop, "Filter", "Which particles to consider in remeshing");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "size_vertex_group", PROP_STRING, PROP_NONE);
+  RNA_def_property_string_sdna(prop, NULL, "size_defgrp_name");
+  RNA_def_property_ui_text(prop, "Size Vertex Group", "Vertex group name which optionally defines metaball size");
+  RNA_def_property_string_funcs(prop, NULL, NULL, "rna_RemeshModifier_size_defgrp_name_set");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  /*voxel remesher*/
+
+  prop = RNA_def_property(srna, "voxel_size", PROP_FLOAT, PROP_UNSIGNED);
+  RNA_def_property_float_funcs(prop, NULL, "rna_RemeshModifier_voxel_size_set", NULL);
+  RNA_def_property_range(prop, 0.001, 1.0);
+  RNA_def_property_float_default(prop, 0.1f);
+  RNA_def_property_ui_range(prop, 0.0001, 1, 0.01, 4);
+  RNA_def_property_ui_text(prop, "Voxel Size", "Voxel size used for volume evaluation");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "smooth_normals", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_SMOOTH_NORMALS);
+  RNA_def_property_ui_text(prop, "Smooth Normals", "Smooth normals on the resulting mesh");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "isovalue", PROP_FLOAT, PROP_UNSIGNED);
+  RNA_def_property_range(prop, 0.0, 1.0);
+  RNA_def_property_float_default(prop, 0.1f);
+  RNA_def_property_ui_range(prop, 0.0, 1, 0.01, 4);
+  RNA_def_property_ui_text(prop, "Isovalue", "Isovalue used for remesher");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "adaptivity", PROP_FLOAT, PROP_UNSIGNED);
+  RNA_def_property_range(prop, 0.0, 1.0);
+  RNA_def_property_float_default(prop, 0.1f);
+  RNA_def_property_ui_range(prop, 0.0, 1, 0.01, 4);
+  RNA_def_property_ui_text(prop, "Adaptivity", "Voxel Adaptivity used for remesher");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "relax_triangles", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_RELAX_TRIANGLES);
+  RNA_def_property_ui_text(
+      prop, "Relax Triangles", "Relax disoriented Triangles on the resulting mesh");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "filter_type", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_items(prop, filter_type_items);
+  RNA_def_property_ui_text(prop, "Filter Type", "OpenVDB Levelset Filter Type");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "filter_bias", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_items(prop, filter_bias_items);
+  RNA_def_property_ui_text(prop, "Filter Bias", "OpenVDB Levelset Filter Bias");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "filter_width", PROP_INT, PROP_UNSIGNED);
+  RNA_def_property_int_sdna(prop, NULL, "filter_width");
+  RNA_def_property_range(prop, 0, INT_MAX);
+  RNA_def_property_ui_text(prop, "Filter Width", "OpenVDB Levelset Filter Width");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "filter_iterations", PROP_INT, PROP_UNSIGNED);
+  RNA_def_property_int_sdna(prop, NULL, "filter_iterations");
+  RNA_def_property_range(prop, 0, INT_MAX);
+  RNA_def_property_ui_text(prop, "Filter Iterations", "OpenVDB Levelset Filter Iterations");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "reproject_vertex_paint", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_REPROJECT_VPAINT);
+  RNA_def_property_ui_text(
+      prop, "Reproject Vertex Paint", "Keep the current vertex paint on the new mesh");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "live_remesh", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_LIVE_REMESH);
+  RNA_def_property_ui_text(
+      prop,
+      "Live Remesh",
+      "Perform remesh on every modifier update, otherwise return cached mesh");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "csg_operands", PROP_COLLECTION, PROP_NONE);
+  RNA_def_property_struct_type(prop, "CSGVolume_Object");
+  RNA_def_property_collection_sdna(prop, NULL, "csg_operands", NULL);
+  RNA_def_property_ui_text(prop, "CSG Volume Operands", "");
+
+  srna = RNA_def_struct(brna, "CSGVolume_Object", NULL);
+  RNA_def_struct_ui_text(
+      srna, "CSG Volume Object", "CSG Volume Object used by the Voxel remesher modifier");
+
+  prop = RNA_def_property(srna, "object", PROP_POINTER, PROP_NONE);
+  RNA_def_property_struct_type(prop, "Object");
+  RNA_def_property_pointer_sdna(prop, NULL, "object");
+  RNA_def_property_pointer_funcs(
+      prop, "rna_CSGVolume_object_get", "rna_CSGVolume_object_set", NULL, "rna_CSG_object_poll");
+  RNA_def_property_flag(prop, PROP_EDITABLE | PROP_ID_SELF_CHECK);
+  RNA_def_property_ui_text(prop, "Object", "Object to use csg operand");
+  RNA_def_property_update(prop, 0, "rna_Modifier_dependency_update");
+
+  prop = RNA_def_property(srna, "operation", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_items(prop, prop_operation_items);
+  RNA_def_property_enum_default(prop, eRemeshModifierOp_Difference);
+  RNA_def_property_ui_text(prop, "Operation", "");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "voxel_size", PROP_FLOAT, PROP_UNSIGNED);
+  RNA_def_property_range(prop, 0.001, 1.0);
+  RNA_def_property_float_default(prop, 0.1f);
+  RNA_def_property_ui_range(prop, 0.0001, 1, 0.01, 4);
+  RNA_def_property_ui_text(prop, "Voxel Size", "Voxel size used for volume evaluation");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "voxel_percentage", PROP_FLOAT, PROP_PERCENTAGE);
+  RNA_def_property_range(prop, 1.0, 100.0);
+  RNA_def_property_float_default(prop, 100.0);
+  RNA_def_property_ui_range(prop, 1.0, 100.0, 0.1, 1);
+  RNA_def_property_ui_text(prop, "Voxel Percentage", "Voxel percentage multiplier");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "enabled", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_CSG_OBJECT_ENABLED);
+  RNA_def_property_ui_text(prop, "Enabled", "Consider this object as part of the csg operations");
+  RNA_def_property_update(prop, 0, "rna_Modifier_dependency_update");
+
+  prop = RNA_def_property(srna, "use_voxel_percentage", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_CSG_VOXEL_PERCENTAGE);
+  RNA_def_property_ui_text(prop, "Percentage", "Use Voxel percentage multiplier");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "sync_voxel_size", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", MOD_REMESH_CSG_SYNC_VOXEL_SIZE);
+  RNA_def_property_ui_text(prop, "Sync Voxel Size", "Keep voxel size in sync");
+  RNA_def_property_update(prop, 0, "rna_Modifier_update");
+
+  prop = RNA_def_property(srna, "sampler", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_items(prop, prop_sampler_items);
+  RNA_def_property_enum_default(prop, eRemeshModifierSampler_Point);
+  RNA_def_property_ui_text(prop, "Sampler", "Method to resample grids to match the transforms");
   RNA_def_property_update(prop, 0, "rna_Modifier_update");
 }
 

--- a/source/blender/makesrna/intern/rna_space.c
+++ b/source/blender/makesrna/intern/rna_space.c
@@ -5489,6 +5489,8 @@ static void rna_def_space_filebrowser(BlenderRNA *brna)
   RNA_def_struct_sdna(srna, "SpaceFile");
   RNA_def_struct_ui_text(srna, "Space File Browser", "File browser space data");
 
+  rna_def_space_generic_show_region_toggles(srna, (1 << RGN_TYPE_TOOLS) | (1 << RGN_TYPE_UI));
+
   prop = RNA_def_property(srna, "params", PROP_POINTER, PROP_NONE);
   RNA_def_property_pointer_sdna(prop, NULL, "params");
   RNA_def_property_ui_text(

--- a/source/blender/modifiers/intern/MOD_openvdb_util.c
+++ b/source/blender/modifiers/intern/MOD_openvdb_util.c
@@ -192,7 +192,7 @@ static Mesh *Mesh_from_VDBGeom(struct OpenVDBGeom *geom, Object *ob)
 		int j;
 
 		OpenVDBGeom_get_quad(geom, i, quad);
-		for (j = 0; j < 4; j++) {
+		for (j = 3; j >= 0; j--) {
 			MLoop *loop = &mloops[loop_index++];
 			loop->v = quad[j];
 		}
@@ -209,7 +209,7 @@ static Mesh *Mesh_from_VDBGeom(struct OpenVDBGeom *geom, Object *ob)
 		int j;
 
 		OpenVDBGeom_get_triangle(geom, i, triangle);
-		for (j = 0; j < 3; j++) {
+		for (j = 2; j >= 0; j--) {
 			MLoop *loop = &mloops[loop_index++];
 			loop->v = triangle[j];
 		}

--- a/source/blender/modifiers/intern/MOD_openvdb_util.c
+++ b/source/blender/modifiers/intern/MOD_openvdb_util.c
@@ -59,15 +59,6 @@ static void populate_particle_list(ParticleMesherModifierData *pmmd, Scene *scen
 		ParticleKey state;
 		int p;
 
-		if (psys->part->size > 0.0f) {
-//			part_list.has_radius(true);
-		}
-
-		/* TODO(kevin): this isn't right at all */
-		if (psys->part->normfac > 0.0f) {
-//			part_list.has_velocity(true);
-		}
-
 		sim.depsgraph = depsgraph;
 		sim.scene = scene;
 		sim.ob = ob;

--- a/source/blender/modifiers/intern/MOD_remesh.c
+++ b/source/blender/modifiers/intern/MOD_remesh.c
@@ -23,18 +23,29 @@
 #include "MEM_guardedalloc.h"
 
 #include "BLI_utildefines.h"
-
+#include "BLI_listbase.h"
 #include "BLI_math_base.h"
+#include "BLI_memarena.h"
 
 #include "DNA_meshdata_types.h"
 #include "DNA_modifier_types.h"
 #include "DNA_object_types.h"
 #include "DNA_mesh_types.h"
+#include "DNA_scene_types.h"
+#include "DNA_particle_types.h"
 
 #include "MOD_modifiertypes.h"
 
+#include "BKE_deform.h"
+#include "BKE_mball_tessellate.h"
 #include "BKE_mesh.h"
 #include "BKE_mesh_runtime.h"
+#include "BKE_library.h"
+#include "BKE_library_query.h"
+#include "BKE_object.h"
+#include "BKE_remesh.h"
+
+#include "DEG_depsgraph_query.h"
 
 #include <assert.h>
 #include <stdlib.h>
@@ -44,6 +55,10 @@
 #  include "BLI_math_vector.h"
 
 #  include "dualcon.h"
+#endif
+
+#ifdef WITH_OPENVDB
+#  include "openvdb_capi.h"
 #endif
 
 static void initData(ModifierData *md)
@@ -56,6 +71,23 @@ static void initData(ModifierData *md)
   rmd->flag = MOD_REMESH_FLOOD_FILL;
   rmd->mode = MOD_REMESH_SHARP_FEATURES;
   rmd->threshold = 1;
+  rmd->voxel_size = 0.1f;
+  rmd->isovalue = 0.0f;
+  rmd->adaptivity = 0.0f;
+  rmd->filter_width = 1;
+  rmd->filter_bias = OPENVDB_LEVELSET_FIRST_BIAS;
+  rmd->filter_type = OPENVDB_LEVELSET_FILTER_NONE;
+  rmd->filter_iterations = 1;
+  rmd->flag |= MOD_REMESH_LIVE_REMESH;
+
+  rmd->basesize[0] = rmd->basesize[1] = rmd->basesize[2] = 1.0f;
+  rmd->thresh = 0.6f;
+  rmd->wiresize = 0.4f;
+  rmd->rendersize = 0.2f;
+	
+  rmd->input = 0;
+  rmd->pflag = 1;
+  rmd->psys = 1;
 }
 
 #ifdef WITH_MOD_REMESH
@@ -133,51 +165,316 @@ static void dualcon_add_quad(void *output_v, const int vert_indices[4])
   output->curface++;
 }
 
-static Mesh *applyModifier(ModifierData *md, const ModifierEvalContext *UNUSED(ctx), Mesh *mesh)
+static int get_particle_data(RemeshModifierData *rmd, ParticleSystem *psys, Object *ob,
+	                             float (**pos)[3], float **size, float (**vel)[3], float(**rot)[4],
+	                             int **index, MemArena *pardata)
 {
-  RemeshModifierData *rmd;
-  DualConOutput *output;
-  DualConInput input;
-  Mesh *result;
-  DualConFlags flags = 0;
-  DualConMode mode = 0;
+	//take alive, for now
+	ParticleData *pa;
+	int i = 0, j = 0;
+	float imat[4][4];
+	invert_m4_m4(imat, ob->obmat);
 
-  rmd = (RemeshModifierData *)md;
+	(*pos) = BLI_memarena_calloc(pardata, sizeof(float) * 3 * psys->totpart);
+	(*size) = BLI_memarena_calloc(pardata, sizeof(float) * psys->totpart);
+	(*vel) = BLI_memarena_calloc(pardata, sizeof(float) * 3 * psys->totpart);
+	(*rot) = BLI_memarena_calloc(pardata, sizeof(float) * 4 * psys->totpart);
+	(*index) = BLI_memarena_calloc(pardata, sizeof(int) * psys->totpart);
 
-  init_dualcon_mesh(&input, mesh);
+	for (i = 0; i < psys->totpart; i++)
+	{
+		float co[3];
+		pa = psys->particles + i;
+		if (pa->alive == PARS_UNBORN && (rmd->pflag & eRemeshFlag_Unborn) == 0) continue;
+		if (pa->alive == PARS_ALIVE && (rmd->pflag & eRemeshFlag_Alive) == 0) continue;
+		if (pa->alive == PARS_DEAD && (rmd->pflag & eRemeshFlag_Dead) == 0) continue;
 
-  if (rmd->flag & MOD_REMESH_FLOOD_FILL) {
-    flags |= DUALCON_FLOOD_FILL;
+		mul_v3_m4v3(co, imat, pa->state.co);
+		copy_v3_v3((*pos)[j], co);
+		(*size)[j] = pa->size;
+		copy_v3_v3((*vel)[j], pa->state.vel);
+		copy_qt_qt((*rot)[j], pa->state.rot);
+		(*index)[j] = i;
+		j++;
+	}
+
+	return j;
+}
+
+static ParticleSystem *get_psys(RemeshModifierData *rmd, Object *ob, Scene* scene, bool render)
+{
+	ParticleSystem *psys;
+	ModifierData *ob_md = (ModifierData*)rmd;
+
+	psys = BLI_findlink(&ob->particlesystem, rmd->psys - 1);
+	if (psys == NULL)
+		return NULL;
+
+	/* If the psys modifier is disabled we cannot use its data.
+	 * First look up the psys modifier from the object, then check if it is enabled.
+	 */
+
+	for (ob_md = ob->modifiers.first; ob_md; ob_md = ob_md->next) {
+		if (ob_md->type == eModifierType_ParticleSystem) {
+			ParticleSystemModifierData *psmd = (ParticleSystemModifierData *)ob_md;
+			if (psmd->psys == psys) {
+				int required_mode;
+
+				if (render) required_mode = eModifierMode_Render;
+				else required_mode = eModifierMode_Realtime;
+
+				if (modifier_isEnabled(scene, ob_md, required_mode))
+				{
+					return psys;
+				}
+
+				return NULL;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+static Mesh *repolygonize(RemeshModifierData *rmd, Object* ob, Mesh* derived, ParticleSystem *psys, bool render)
+{
+	Mesh *dm = NULL, *result = NULL;
+	MVert *mv = NULL, *mv2 = NULL;
+	float (*pos)[3] = NULL, (*vel)[3] = NULL, (*rot)[4] = NULL;
+	float *size = NULL, *psize = NULL, *velX = NULL, *velY = NULL, *velZ = NULL,
+	      *quatX = NULL, *quatY = NULL, *quatZ = NULL, *quatW = NULL;
+	int i = 0, n = 0, *index, *orig_index;
+	bool override_size = rmd->pflag & eRemeshFlag_Size;
+	bool verts_only = rmd->pflag & eRemeshFlag_Verts;
+	MDeformVert *dvert = NULL;
+	int defgrp_size = -1;
+
+	if (rmd->size_defgrp_name[0])
+	{
+		defgrp_size = defgroup_name_index(ob, rmd->size_defgrp_name);
+		dvert = CustomData_get_layer(&derived->vdata, CD_MDEFORMVERT);
+	}
+
+	if (((rmd->input & MOD_REMESH_VERTICES)==0) && (rmd->input & MOD_REMESH_PARTICLES))
+	{
+		//particles only
+		MemArena *pardata = NULL;
+		if (psys == NULL)
+			return derived;
+
+		pardata = BLI_memarena_new(BLI_MEMARENA_STD_BUFSIZE, "pardata");
+
+		n = get_particle_data(rmd, psys, ob, &pos, &size, &vel, &rot, &index, pardata);
+		dm = BKE_mesh_new_nomain(n, 0, 0, 0, 0);
+		mv = dm->mvert;
+		psize = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "psize");
+		velX = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "velX");
+		velY = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "velY");
+		velZ = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "velZ");
+
+		quatX = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "quatX");
+		quatY = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "quatY");
+		quatZ = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "quatZ");
+		quatW = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n, "quatW");
+
+		orig_index = CustomData_add_layer(&dm->vdata, CD_ORIGINDEX, CD_CALLOC, NULL, n);
+
+		for (i = 0; i < n; i++)
+		{
+			copy_v3_v3(mv[i].co, pos[i]);
+			psize[i] = size[i];
+			velX[i] = vel[i][0];
+			velY[i] = vel[i][1];
+			velZ[i] = vel[i][2];
+
+			quatX[i] = rot[i][0];
+			quatY[i] = rot[i][1];
+			quatZ[i] = rot[i][2];
+			quatW[i] = rot[i][3];
+
+			orig_index[i] = index[i];
+		}
+
+		if (verts_only)
+		{
+			BLI_memarena_free(pardata);
+			return dm;
+		}
+		else {
+			BLI_memarena_free(pardata);
+			result = BKE_repolygonize_dm(dm, rmd->thresh, rmd->basesize, rmd->wiresize, rmd->rendersize, render,
+			                             override_size, defgrp_size);
+			BKE_mesh_free(dm);
+			return result;
+		}
+	}
+	else if ((rmd->input & MOD_REMESH_VERTICES) && ((rmd->input & MOD_REMESH_PARTICLES) == 0))
+	{
+		//verts only
+		Mesh *result = NULL;
+		result = BKE_repolygonize_dm(derived, rmd->thresh, rmd->basesize, rmd->wiresize,
+		                             rmd->rendersize, render, override_size, defgrp_size);
+		return result;
+	}
+	else if ((rmd->input & MOD_REMESH_VERTICES) && (rmd->input & MOD_REMESH_PARTICLES))
+	{
+		//both, for simplicity only use vert data here
+		float* ovX, *ovY, *ovZ, *oqX, *oqY, *oqZ, *oqW;
+		n = 0;
+		MemArena *pardata = BLI_memarena_new(BLI_MEMARENA_STD_BUFSIZE, "pardata");
+		MDeformVert *dvert_new = NULL;
+
+		if (psys)
+			n = get_particle_data(rmd, psys, ob, &pos, &size, &vel, &rot, &index, pardata);
+
+		dm = BKE_mesh_new_nomain(n + derived->totvert, 0, 0, 0, 0);
+		psize = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "psize");
+		velX = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "velX");
+		velY = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "velY");
+		velZ = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "velZ");
+
+		quatX = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "quatX");
+		quatY = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "quatY");
+		quatZ = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "quatZ");
+		quatW = CustomData_add_layer_named(&dm->vdata, CD_PROP_FLT, CD_CALLOC, NULL, n + derived->totvert, "quatW");
+
+		orig_index = CustomData_add_layer(&dm->vdata, CD_ORIGINDEX, CD_CALLOC, NULL, n + derived->totvert);
+
+		if (dvert && defgrp_size > -1) {
+			dvert_new = CustomData_add_layer(&dm->vdata, CD_MDEFORMVERT, CD_CALLOC, NULL, n + derived->totvert);
+		}
+
+		mv = dm->mvert;
+		mv2 = derived->mvert;
+
+		ovX = CustomData_get_layer_named(&derived->vdata, CD_PROP_FLT, "velX");
+		ovY = CustomData_get_layer_named(&derived->vdata, CD_PROP_FLT, "velY");
+		ovZ = CustomData_get_layer_named(&derived->vdata, CD_PROP_FLT, "velZ");
+
+		oqX = CustomData_get_layer_named(&derived->vdata, CD_PROP_FLT, "quatX");
+		oqY = CustomData_get_layer_named(&derived->vdata, CD_PROP_FLT, "quatY");
+		oqZ = CustomData_get_layer_named(&derived->vdata, CD_PROP_FLT, "quatZ");
+		oqW = CustomData_get_layer_named(&derived->vdata, CD_PROP_FLT, "quatW");
+
+		for (i = 0; i < n; i++)
+		{
+			copy_v3_v3(mv[i].co, pos[i]);
+			psize[i] = size[i];
+			velX[i] = vel[i][0];
+			velY[i] = vel[i][1];
+			velZ[i] = vel[i][2];
+
+			quatX[i] = rot[i][0];
+			quatY[i] = rot[i][1];
+			quatZ[i] = rot[i][2];
+			quatW[i] = rot[i][3];
+
+			orig_index[i] = index[i];
+
+			if (dvert_new && dvert && defgrp_size > -1)
+			{
+				defvert_add_index_notest(dvert_new + i, defgrp_size, 1.0f);
+			}
+		}
+
+		for (i = n; i < n + derived->totvert; i++)
+		{
+			copy_v3_v3(mv[i].co, mv2[i-n].co);
+			psize[i] = -1.0f; //use mball sizep
+			velX[i] = ovX ? ovX[i-n] : 0.0f;
+			velY[i] = ovY ? ovY[i-n] : 0.0f;
+			velZ[i] = ovZ ? ovZ[i-n] : 0.0f;
+
+			quatX[i] = oqX ? oqX[i-n] : 1.0f;
+			quatZ[i] = oqY ? oqY[i-n] : 0.0f;
+			quatY[i] = oqZ ? oqZ[i-n] : 0.0f;
+			quatW[i] = oqW ? oqW[i-n] : 0.0f;
+
+			orig_index[i] = i;
+			if (dvert_new && dvert && defgrp_size > -1)
+			{
+				int ind = i-n;
+				MDeformWeight *dw = (dvert + ind)->dw;
+				float w = 1.0f;
+				if (dw)
+				{
+					w = dw[defgrp_size].weight;
+				}
+
+				defvert_add_index_notest(dvert_new + i, defgrp_size, w);
+			}
+		}
+
+		if (verts_only)
+		{
+			BLI_memarena_free(pardata);
+			return dm;
+		}
+		else {
+			BLI_memarena_free(pardata);
+			result = BKE_repolygonize_dm(dm, rmd->thresh, rmd->basesize, rmd->wiresize, rmd->rendersize, render, override_size, defgrp_size);
+			BKE_mesh_free(dm);
+			return result;
+		}
+	}
+
+	return NULL;
+}
+
+#  ifdef WITH_OPENVDB
+
+static Mesh *voxel_remesh(RemeshModifierData *rmd, Mesh *mesh, struct OpenVDBLevelSet *level_set)
+{
+  MLoopCol **remap = NULL;
+  Mesh *target = NULL;
+
+  if (rmd->flag & MOD_REMESH_REPROJECT_VPAINT) {
+    CSGVolume_Object *vcob;
+    int i = 1;
+    remap = MEM_calloc_arrayN(
+        BLI_listbase_count(&rmd->csg_operands) + 1, sizeof(MLoopCol *), "remap");
+    remap[0] = BKE_remesh_remap_loop_vertex_color_layer(mesh);
+    for (vcob = rmd->csg_operands.first; vcob; vcob = vcob->next) {
+      if (vcob->object && vcob->flag & MOD_REMESH_CSG_OBJECT_ENABLED) {
+        Mesh *me = BKE_object_get_final_mesh(vcob->object);
+        remap[i] = BKE_remesh_remap_loop_vertex_color_layer(me);
+        i++;
+      }
+    }
   }
 
-  switch (rmd->mode) {
-    case MOD_REMESH_CENTROID:
-      mode = DUALCON_CENTROID;
-      break;
-    case MOD_REMESH_MASS_POINT:
-      mode = DUALCON_MASS_POINT;
-      break;
-    case MOD_REMESH_SHARP_FEATURES:
-      mode = DUALCON_SHARP_FEATURES;
-      break;
+  OpenVDBLevelSet_filter(
+      level_set, rmd->filter_type, rmd->filter_width, rmd->filter_iterations, rmd->filter_bias);
+  target = BKE_remesh_voxel_ovdb_volume_to_mesh_nomain(
+      level_set, rmd->isovalue, rmd->adaptivity, rmd->flag & MOD_REMESH_RELAX_TRIANGLES);
+  OpenVDBLevelSet_free(level_set);
+
+  if (rmd->flag & MOD_REMESH_REPROJECT_VPAINT) {
+    int i = 1;
+    CSGVolume_Object *vcob;
+
+    if (remap[0]) {
+      BKE_remesh_voxel_reproject_remapped_vertex_paint(target, mesh, remap[0]);
+      MEM_freeN(remap[0]);
+    }
+
+    for (vcob = rmd->csg_operands.first; vcob; vcob = vcob->next) {
+      if (vcob->object && vcob->flag & MOD_REMESH_CSG_OBJECT_ENABLED && remap && remap[i]) {
+        Mesh *me = BKE_object_get_final_mesh(vcob->object);
+        BKE_remesh_voxel_reproject_remapped_vertex_paint(target, me, remap[i]);
+        if (remap[i])
+          MEM_freeN(remap[i]);
+        i++;
+      }
+    }
+
+    MEM_freeN(remap);
+    BKE_mesh_update_customdata_pointers(target, false);
   }
 
-  output = dualcon(&input,
-                   dualcon_alloc_output,
-                   dualcon_add_vert,
-                   dualcon_add_quad,
-                   flags,
-                   mode,
-                   rmd->threshold,
-                   rmd->hermite_num,
-                   rmd->scale,
-                   rmd->depth);
-  result = output->mesh;
-  MEM_freeN(output);
-
-  if (rmd->flag & MOD_REMESH_SMOOTH_SHADING) {
-    MPoly *mpoly = result->mpoly;
-    int i, totpoly = result->totpoly;
+  if (rmd->flag & MOD_REMESH_SMOOTH_NORMALS) {
+    MPoly *mpoly = target->mpoly;
+    int i, totpoly = target->totpoly;
 
     /* Apply smooth shading to output faces */
     for (i = 0; i < totpoly; i++) {
@@ -185,8 +482,189 @@ static Mesh *applyModifier(ModifierData *md, const ModifierEvalContext *UNUSED(c
     }
   }
 
-  BKE_mesh_calc_edges(result, true, false);
-  result->runtime.cd_dirty_vert |= CD_MASK_NORMAL;
+  return target;
+}
+
+static struct OpenVDBLevelSet *csgOperation(struct OpenVDBLevelSet *level_set,
+                                            CSGVolume_Object *vcob,
+                                            Object *ob,
+                                            RemeshModifierData *rmd)
+{
+  Mesh *me_orig = BKE_object_get_final_mesh(vcob->object);
+  Mesh *me = BKE_mesh_new_nomain(
+      me_orig->totvert, me_orig->totedge, me_orig->totface, me_orig->totloop, me_orig->totpoly);
+
+  BKE_mesh_nomain_to_mesh(me_orig, me, vcob->object, &CD_MASK_MESH, false);
+
+  float imat[4][4];
+  float omat[4][4];
+  float size = (vcob->flag & MOD_REMESH_CSG_VOXEL_PERCENTAGE) ?
+                   rmd->voxel_size * vcob->voxel_percentage / 100.0f :
+                   vcob->voxel_size;
+
+  invert_m4_m4(imat, ob->obmat);
+  mul_m4_m4m4(omat, imat, vcob->object->obmat);
+
+  for (int i = 0; i < me->totvert; i++) {
+    mul_m4_v3(omat, me->mvert[i].co);
+  }
+
+  struct OpenVDBTransform *xform = OpenVDBTransform_create();
+  OpenVDBTransform_create_linear_transform(xform, size);
+
+  struct OpenVDBLevelSet *level_setB = BKE_remesh_voxel_ovdb_mesh_to_level_set_create(me, xform);
+
+  if (vcob->sampler != OPENVDB_LEVELSET_GRIDSAMPLER_NONE) {
+    level_set = OpenVDBLevelSet_transform_and_resample(
+        level_set, level_setB, vcob->sampler, rmd->isovalue);
+  }
+
+  OpenVDBLevelSet_CSG_operation(
+      level_set, level_set, level_setB, (OpenVDBLevelSet_CSGOperation)vcob->operation);
+
+  OpenVDBLevelSet_free(level_setB);
+  OpenVDBTransform_free(xform);
+  BKE_mesh_free(me);
+
+  return level_set;
+}
+
+static Mesh *copy_mesh(Mesh *me)
+{
+  Mesh *result = BKE_mesh_new_nomain(
+      me->totvert, me->totedge, me->totface, me->totloop, me->totpoly);
+
+  BKE_mesh_nomain_to_mesh(me, result, NULL, &CD_MASK_MESH, false);
+  return result;
+}
+#  endif
+
+static Mesh *applyModifier(ModifierData *md, const ModifierEvalContext *ctx, Mesh *mesh)
+{
+  RemeshModifierData *rmd;
+  DualConOutput *output;
+  DualConInput input;
+  Mesh *result = NULL;
+  DualConFlags flags = 0;
+  DualConMode mode = 0;
+
+  rmd = (RemeshModifierData *)md;
+
+  if (rmd->mode == MOD_REMESH_VOXEL) {
+#  if defined WITH_OPENVDB
+    CSGVolume_Object *vcob;
+    struct OpenVDBLevelSet *level_set;
+
+    Object *ob_orig = DEG_get_original_object(ctx->object);
+    RemeshModifierData *rmd_orig = (RemeshModifierData *)modifiers_findByName(ob_orig, md->name);
+
+    if (((rmd->flag & MOD_REMESH_LIVE_REMESH) == 0)) {
+      // access mesh cache on ORIGINAL object, cow should not copy / free this over and over again
+      if (rmd_orig->mesh_cached) {
+        return copy_mesh(rmd_orig->mesh_cached);
+      }
+    }
+
+    if (rmd->voxel_size > 0.0f) {
+
+      struct OpenVDBTransform *xform = OpenVDBTransform_create();
+      OpenVDBTransform_create_linear_transform(xform, rmd->voxel_size);
+      level_set = BKE_remesh_voxel_ovdb_mesh_to_level_set_create(mesh, xform);
+      OpenVDBTransform_free(xform);
+
+      for (vcob = rmd->csg_operands.first; vcob; vcob = vcob->next) {
+        if (vcob->object && (vcob->flag & MOD_REMESH_CSG_OBJECT_ENABLED)) {
+          level_set = csgOperation(level_set, vcob, ctx->object, rmd);
+        }
+      }
+
+      result = voxel_remesh(rmd, mesh, level_set);
+
+      if (result) {
+        // update cache
+        if (rmd_orig->mesh_cached) {
+          BKE_mesh_free(rmd_orig->mesh_cached);
+          rmd_orig->mesh_cached = NULL;
+        }
+
+        // save a copy
+        rmd_orig->mesh_cached = copy_mesh(result);
+      }
+
+      return result;
+    }
+    else {
+      return mesh;
+    }
+#  else
+    modifier_setError((ModifierData *)rmd,
+                      "Built without OpenVDB support, cant execute voxel remesh");
+    return mesh;
+#  endif
+  }
+
+  if (rmd->mode == MOD_REMESH_METABALL) {
+    ParticleSystem* psys = NULL;
+	bool render = ctx->flag & MOD_APPLY_RENDER;
+	psys = get_psys(rmd, ctx->object, DEG_get_input_scene(ctx->depsgraph), render);
+	result = repolygonize(rmd, ctx->object, mesh, psys, render);
+
+    if (result && (rmd->flag & MOD_REMESH_SMOOTH_SHADING)) {
+		MPoly *mpoly = result->mpoly;
+		int i, totpoly = result->totpoly;
+
+		/* Apply smooth shading to output faces */
+		for (i = 0; i < totpoly; i++) {
+			mpoly[i].flag |= ME_SMOOTH;
+		}
+	}
+  }
+  else
+  {
+      init_dualcon_mesh(&input, mesh);
+
+      if (rmd->flag & MOD_REMESH_FLOOD_FILL)
+        flags |= DUALCON_FLOOD_FILL;
+
+      switch (rmd->mode) {
+        case MOD_REMESH_CENTROID:
+          mode = DUALCON_CENTROID;
+          break;
+        case MOD_REMESH_MASS_POINT:
+          mode = DUALCON_MASS_POINT;
+          break;
+        case MOD_REMESH_SHARP_FEATURES:
+          mode = DUALCON_SHARP_FEATURES;
+          break;
+      }
+
+      output = dualcon(&input,
+                       dualcon_alloc_output,
+                       dualcon_add_vert,
+                       dualcon_add_quad,
+                       flags,
+                       mode,
+                       rmd->threshold,
+                       rmd->hermite_num,
+                       rmd->scale,
+                       rmd->depth);
+      result = output->mesh;
+      MEM_freeN(output);
+
+      if (rmd->flag & MOD_REMESH_SMOOTH_SHADING) {
+        MPoly *mpoly = result->mpoly;
+        int i, totpoly = result->totpoly;
+
+        /* Apply smooth shading to output faces */
+        for (i = 0; i < totpoly; i++) {
+          mpoly[i].flag |= ME_SMOOTH;
+        }
+      }
+
+      BKE_mesh_calc_edges(result, true, false);
+      result->runtime.cd_dirty_vert |= CD_MASK_NORMAL;
+  }
+
   return result;
 }
 
@@ -201,15 +679,104 @@ static Mesh *applyModifier(ModifierData *UNUSED(md),
 
 #endif /* !WITH_MOD_REMESH */
 
+static void requiredDataMask(Object *UNUSED(ob),
+                             ModifierData *md,
+                             CustomData_MeshMasks *r_cddata_masks)
+{
+  RemeshModifierData *rmd = (RemeshModifierData *)md;
+
+  /* ask for vertexcolors if we need them */
+  if (rmd->mode == MOD_REMESH_VOXEL) {
+    r_cddata_masks->lmask |= CD_MASK_MLOOPCOL;
+  }
+}
+
+static void foreachObjectLink(ModifierData *md, Object *ob, ObjectWalkFunc walk, void *userData)
+{
+  RemeshModifierData *rmd = (RemeshModifierData *)md;
+  CSGVolume_Object *vcob;
+
+  if (rmd->mode != MOD_REMESH_VOXEL) {
+    return;
+  }
+
+  if (((rmd->flag & MOD_REMESH_LIVE_REMESH) == 0) && rmd->mesh_cached) {
+    return;
+  }
+
+  for (vcob = rmd->csg_operands.first; vcob; vcob = vcob->next) {
+    if (vcob->object) {
+      walk(userData, ob, &vcob->object, IDWALK_CB_NOP);
+    }
+  }
+}
+
+static void updateDepsgraph(ModifierData *md, const ModifierUpdateDepsgraphContext *ctx)
+{
+  RemeshModifierData *rmd = (RemeshModifierData *)md;
+  CSGVolume_Object *vcob;
+
+  if (rmd->mode != MOD_REMESH_VOXEL) {
+    return;
+  }
+
+  if (((rmd->flag & MOD_REMESH_LIVE_REMESH) == 0) && rmd->mesh_cached) {
+    return;
+  }
+
+  for (vcob = rmd->csg_operands.first; vcob; vcob = vcob->next) {
+    if (vcob->object && (vcob->flag & MOD_REMESH_CSG_OBJECT_ENABLED)) {
+      DEG_add_object_relation(ctx->node, vcob->object, DEG_OB_COMP_TRANSFORM, "Remesh Modifier");
+      DEG_add_object_relation(ctx->node, vcob->object, DEG_OB_COMP_GEOMETRY, "Remesh Modifier");
+    }
+  }
+
+  if (rmd->csg_operands.first) {
+    /* We need own transformation as well in case we have operands */
+    DEG_add_modifier_to_transform_relation(ctx->node, "Remesh Modifier");
+  }
+}
+
+static void copyData(const ModifierData *md_src, ModifierData *md_dst, const int flag)
+{
+  RemeshModifierData *rmd_src = (RemeshModifierData *)md_src;
+  RemeshModifierData *rmd_dst = (RemeshModifierData *)md_dst;
+  Mesh *me_src = rmd_src->mesh_cached;
+
+  modifier_copyData_generic(md_src, md_dst, flag);
+  // only for cow copy, because cow does shallow copy only
+  if (flag & LIB_ID_CREATE_NO_MAIN) {
+    BLI_duplicatelist(&rmd_dst->csg_operands, &rmd_src->csg_operands);
+  }
+
+  // here for both ?
+  if (me_src) {
+    Mesh *me_dst = BKE_mesh_new_nomain(
+        me_src->totvert, me_src->totedge, me_src->totface, me_src->totloop, me_src->totpoly);
+
+    BKE_mesh_nomain_to_mesh(me_src, me_dst, NULL, &CD_MASK_MESH, false);
+    rmd_dst->mesh_cached = me_dst;
+  }
+}
+
+static void freeData(ModifierData *md)
+{
+  RemeshModifierData *rmd = (RemeshModifierData *)md;
+  if (rmd->mesh_cached) {
+    BKE_mesh_free(rmd->mesh_cached);
+    rmd->mesh_cached = NULL;
+  }
+}
+
 ModifierTypeInfo modifierType_Remesh = {
     /* name */ "Remesh",
     /* structName */ "RemeshModifierData",
     /* structSize */ sizeof(RemeshModifierData),
-    /* type */ eModifierTypeType_Nonconstructive,
+    /* type */ eModifierTypeType_Constructive,
     /* flags */ eModifierTypeFlag_AcceptsMesh | eModifierTypeFlag_AcceptsCVs |
-        eModifierTypeFlag_SupportsEditmode,
+        eModifierTypeFlag_SupportsEditmode | eModifierTypeFlag_SupportsMapping,
 
-    /* copyData */ modifier_copyData_generic,
+    /* copyData */ copyData,
 
     /* deformVerts */ NULL,
     /* deformMatrices */ NULL,
@@ -218,13 +785,13 @@ ModifierTypeInfo modifierType_Remesh = {
     /* applyModifier */ applyModifier,
 
     /* initData */ initData,
-    /* requiredDataMask */ NULL,
-    /* freeData */ NULL,
+    /* requiredDataMask */ requiredDataMask,
+    /* freeData */ freeData,
     /* isDisabled */ NULL,
-    /* updateDepsgraph */ NULL,
+    /* updateDepsgraph */ updateDepsgraph,
     /* dependsOnTime */ NULL,
     /* dependsOnNormals */ NULL,
-    /* foreachObjectLink */ NULL,
+    /* foreachObjectLink */ foreachObjectLink,
     /* foreachIDLink */ NULL,
     /* freeRuntimeData */ NULL,
 };


### PR DESCRIPTION
those commits add the metaball remeshers and openvdb voxel remesh mode with CSG booleans. 
Note: I was not able to build with OIDN properly, but this should be a plain build issue. My changes didnt touch the denoising functionality. The existing particle mesher should still work as expected, too.
Update: the compilation and linkage seemed to be successful, but on starting blender it immediately crashed with: 

`./bin/blender.app/Contents/MacOS/blender 
dyld: Library not loaded: @rpath/libOpenImageDenoise.0.dylib
  Referenced from: /Users/martin/blender_gitlab/build_darwin_full_openvdb_mesher_full/./bin/blender.app/Contents/MacOS/blender
  Reason: image not found
Abort trap: 6 `

Seems it looked for OIDN in the wrong directory or so...