### PR TITLE
Volumetrics: Blend from last frame to avoid ugly banding in viewport

### DIFF
--- a/release/scripts/startup/bl_ui/properties_render.py
+++ b/release/scripts/startup/bl_ui/properties_render.py
@@ -300,6 +300,17 @@ class RENDER_PT_eevee_volumetric_shadows(RenderButtonsPanel, Panel):
         layout.active = props.use_volumetric_shadows
         layout.prop(props, "volumetric_shadow_samples", text="Samples")
 
+class RENDER_PT_eevee_volumetric_blending(RenderButtonsPanel, Panel):
+    bl_label = "Volumetric Blending"
+    bl_parent_id = "RENDER_PT_eevee_volumetric"
+    COMPAT_ENGINES = {'BLENDER_EEVEE'}
+
+    def draw_header(self, context):
+        scene = context.scene
+        props = scene.eevee
+        self.layout.prop(props, "use_volumetric_blending", text="")
+    def draw(self, context):
+        pass
 
 class RENDER_PT_eevee_subsurface_scattering(RenderButtonsPanel, Panel):
     bl_label = "Subsurface Scattering"
@@ -703,6 +714,7 @@ classes = (
     RENDER_PT_eevee_volumetric,
     RENDER_PT_eevee_volumetric_lighting,
     RENDER_PT_eevee_volumetric_shadows,
+    RENDER_PT_eevee_volumetric_blending,
     RENDER_PT_eevee_performance,
     RENDER_PT_eevee_hair,
     RENDER_PT_eevee_shadows,

--- a/source/blender/draw/engines/eevee/eevee_volumes.c
+++ b/source/blender/draw/engines/eevee/eevee_volumes.c
@@ -167,7 +167,9 @@ void EEVEE_volumes_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
   }
 
   if (do_taa) {
-    common_data->vol_history_alpha = 0.0f;
+    if (!(scene_eval->eevee.flag & SCE_EEVEE_VOLUMETRIC_BLENDING)) { /* BoneMaster, Force to use frostbite's paper solution (blend from last frame) to avoid ugly banding */
+      common_data->vol_history_alpha = 0.0f;
+    }
     current_sample = effects->taa_current_sample - 1;
     effects->volume_current_sample = -1;
   }

--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -2413,6 +2413,7 @@ enum {
   SCE_EEVEE_GI_AUTOBAKE = (1 << 19),
   SCE_EEVEE_SHADOW_SOFT = (1 << 20),
   SCE_EEVEE_OVERSCAN = (1 << 21),
+  SCE_EEVEE_VOLUMETRIC_BLENDING = (1 << 22),
 };
 
 /* SceneEEVEE->shadow_method */

--- a/source/blender/makesrna/intern/rna_scene.c
+++ b/source/blender/makesrna/intern/rna_scene.c
@@ -7261,6 +7261,13 @@ static void rna_def_scene_eevee(BlenderRNA *brna)
   RNA_def_property_override_flag(prop, PROPOVERRIDE_OVERRIDABLE_LIBRARY);
   RNA_def_property_update(prop, NC_SCENE | ND_RENDER_OPTIONS, NULL);
 
+  prop = RNA_def_property(srna, "use_volumetric_blending", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", SCE_EEVEE_VOLUMETRIC_BLENDING);
+  RNA_def_property_ui_text(
+        prop, "Volumetric Blending", "Enable volumes blending with previous frame");
+  RNA_def_property_override_flag(prop, PROPOVERRIDE_OVERRIDABLE_LIBRARY);
+  RNA_def_property_update(prop, NC_SCENE | ND_RENDER_OPTIONS, NULL);
+
   prop = RNA_def_property(srna, "volumetric_light_clamp", PROP_FLOAT, PROP_NONE);
   RNA_def_property_range(prop, 0.0f, FLT_MAX);
   RNA_def_property_ui_text(prop, "Clamp", "Maximum light contribution, reducing noise");


### PR DESCRIPTION
Como comentaste en el video que hiciste ayer sobre Blender VR que tenías problemas con el banding de las volumétricas en el viewport, te paso este Pull request que te añade una opción para que las volumetricas de cada frame hagan un blend al 95% con el anterior frame y de esta manera desaparezca el banding.

El patch no añade mucho código. Te paso un video donde se ve mas o menos como queda. El video es del patch sobre UPBGE pero se ve bastante bien aunque los controles no son los mismos (en este patch el botón se llama volumetric Blending y está en la zona de volumétricas): https://www.youtube.com/watch?v=onCc3O4P_S8&feature=youtu.be